### PR TITLE
Several bug fixes. Documentation updates. Add functionality. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dlc_analysis.py
 dlc_workflow.py
 **/__pycache__
 settings.json
+dgramling_trodes_source.py

--- a/spyglass_dlc/__init__.py
+++ b/spyglass_dlc/__init__.py
@@ -38,6 +38,8 @@ from .dlc_utils import (
     find_full_path,
     find_root_directory,
     _convert_mp4,
+    check_videofile,
+    get_video_path,
 )
 
 
@@ -54,4 +56,7 @@ _schemas = [
     "dgramling_dlc_cohort",
     "dgramling_dlc_centroid",
     "dgramling_dlc_orient",
+    "dgramling_dlc_selection",
+    "dgramling_trodes_position",
+    "dgramling_position",
 ]

--- a/spyglass_dlc/__init__.py
+++ b/spyglass_dlc/__init__.py
@@ -25,6 +25,13 @@ from .dgramling_dlc_orient import (
     DLCOrientationSelection,
     DLCOrientation,
 )
+from .dgramling_dlc_selection import DLCPosSelection, DLCPos
+from .dgramling_trodes_position import TrodesPosParams, TrodesPosSelection, TrodesPos
+from .dgramling_position import (
+    PosSelect,
+    IntervalPositionInfo,
+    IntervalPositionInfoSelection,
+)
 from .dlc_utils import (
     get_dlc_root_data_dir,
     get_dlc_processed_data_dir,

--- a/spyglass_dlc/__init__.py
+++ b/spyglass_dlc/__init__.py
@@ -25,10 +25,11 @@ from .dgramling_dlc_orient import (
     DLCOrientationSelection,
     DLCOrientation,
 )
-from .dgramling_dlc_selection import DLCPosSelection, DLCPos
+from .dgramling_dlc_selection import DLCPosSelection, DLCPos, DLCPosVideo
 from .dgramling_trodes_position import TrodesPosParams, TrodesPosSelection, TrodesPos
 from .dgramling_position import (
     PosSelect,
+    PosSource,
     IntervalPositionInfo,
     IntervalPositionInfoSelection,
 )
@@ -40,6 +41,11 @@ from .dlc_utils import (
     _convert_mp4,
     check_videofile,
     get_video_path,
+)
+from .dlc_reader import (
+    read_yaml,
+    save_yaml,
+    do_pose_estimation,
 )
 
 

--- a/spyglass_dlc/dgramling_dlc_centroid.py
+++ b/spyglass_dlc/dgramling_dlc_centroid.py
@@ -210,7 +210,7 @@ class DLCCentroid(dj.Computed):
         centroid = centroid_func(pos_df, **params["points"])
         velocity = get_velocity(
             centroid,
-            time=pos_df["time"],
+            time=pos_df.index.to_numpy(),
             sigma=speed_smoothing_std_dev,
             sampling_frequency=sampling_rate,
         )  # cm/s
@@ -219,10 +219,10 @@ class DLCCentroid(dj.Computed):
         velocity_df = pd.DataFrame(
             np.concatenate((velocity, speed[:, np.newaxis]), axis=1),
             columns=["velocity_x", "velocity_y", "speed"],
-            index=pos_df["time"],
+            index=pos_df.index.to_numpy(),
         )
         final_df = pd.DataFrame(
-            centroid, columns=["position_x", "position_y"], index=pos_df["time"]
+            centroid, columns=["position_x", "position_y"], index=pos_df.index.to_numpy()
         )
         # Add to Analysis NWB file
         nwb_analysis_file = AnalysisNwbfile()

--- a/spyglass_dlc/dgramling_dlc_centroid.py
+++ b/spyglass_dlc/dgramling_dlc_centroid.py
@@ -2,11 +2,13 @@ from functools import reduce
 import numpy as np
 import pandas as pd
 import datajoint as dj
+import pynwb
 from spyglass.common.dj_helper_fn import fetch_nwb
 from spyglass.common.common_nwbfile import AnalysisNwbfile
 from position_tools import get_velocity
 from .dgramling_dlc_position import DLCSmoothInterpParams
 from .dgramling_dlc_cohort import DLCSmoothInterpCohort
+from spyglass.common.common_behav import RawPosition
 
 schema = dj.schema("dgramling_dlc_centroid")
 
@@ -85,6 +87,7 @@ class DLCCentroidSelection(dj.Manual):
 
     definition = """
     -> DLCSmoothInterpCohort
+    -> DLCSmoothInterpParams
     -> DLCCentroidParams
     ---
     """
@@ -100,17 +103,16 @@ class DLCCentroid(dj.Computed):
     -> DLCCentroidSelection
     ---
     -> AnalysisNwbfile
-    dlc_centroid_object_id : varchar(80)
+    dlc_position_object_id : varchar(80)
     dlc_velocity_object_id : varchar(80)
     """
 
     def make(self, key):
-        key["analysis_file_name"] = AnalysisNwbfile().create(key["nwb_file_name"])
         # Get labels to smooth from Parameters table
         cohort_entries = DLCSmoothInterpCohort.BodyPart & key
         params = (DLCCentroidParams() & key).fetch1("params")
         centroid_method = params.pop("centroid_method")
-        bodyparts_avail = cohort_entries.fetch("bodyparts")
+        bodyparts_avail = cohort_entries.fetch("bodypart")
         # Get params from Smooth Interp for speed calculation...
         # Maybe just have user add these to params for CentroidParams?
         smooth_interp_params = (DLCSmoothInterpParams() & key).fetch1("params")
@@ -198,7 +200,8 @@ class DLCCentroid(dj.Computed):
                     DLCSmoothInterpCohort.BodyPart & {**key, **{"bodypart": bodypart}}
                 ).fetch1_dataframe()
                 for bodypart in bodyparts_to_use
-            }
+            },
+            axis=1,
         )
 
         # TODO: not sure where to implement the distance check given potentially 4 bodyparts
@@ -222,18 +225,45 @@ class DLCCentroid(dj.Computed):
             index=pos_df.index.to_numpy(),
         )
         final_df = pd.DataFrame(
-            centroid, columns=["position_x", "position_y"], index=pos_df.index.to_numpy()
+            centroid,
+            columns=["position_x", "position_y"],
+            index=pos_df.index.to_numpy(),
+        )
+        position = pynwb.behavior.Position()
+        velocity = pynwb.behavior.BehavioralTimeSeries()
+        spatial_series = (RawPosition() & key).fetch_nwb()[0]["raw_position"]
+        METERS_PER_CM = 0.01  # IS this needed?
+        idx = pd.IndexSlice
+        position.create_spatial_series(
+            name="position",
+            timestamps=final_df.index.to_numpy(),
+            conversion=METERS_PER_CM,
+            data=final_df.loc[:, idx[("position_x", "position_y")]].to_numpy(),
+            reference_frame=spatial_series.reference_frame,
+            comments=spatial_series.comments,
+            description="x_position, y_position",
+        )
+        velocity.create_timeseries(
+            name="velocity",
+            timestamps=velocity_df.index.to_numpy(),
+            conversion=METERS_PER_CM,
+            unit="m/s",
+            data=velocity_df.loc[
+                :, idx[("velocity_x", "velocity_y", "speed")]
+            ].to_numpy(),
+            comments=spatial_series.comments,
+            description="x_velocity, y_velocity, speed",
         )
         # Add to Analysis NWB file
+        key["analysis_file_name"] = AnalysisNwbfile().create(key["nwb_file_name"])
         nwb_analysis_file = AnalysisNwbfile()
-        key["dlc_centroid_object_id"] = nwb_analysis_file.add_nwb_object(
-            analysis_file_name=key["analysis_file_name"],
-            nwb_object=final_df,
+        key["dlc_position_object_id"] = nwb_analysis_file.add_nwb_object(
+            key["analysis_file_name"], position
         )
         key["dlc_velocity_object_id"] = nwb_analysis_file.add_nwb_object(
-            analysis_file_name=key["analysis_file_name"],
-            nwb_object=velocity_df,
+            key["analysis_file_name"], velocity
         )
+
         nwb_analysis_file.add(
             nwb_file_name=key["nwb_file_name"],
             analysis_file_name=key["analysis_file_name"],
@@ -247,6 +277,10 @@ class DLCCentroid(dj.Computed):
 
     def fetch1_dataframe(self):
         nwb_data = self.fetch_nwb()[0]
+        index = pd.Index(
+            np.asarray(nwb_data["dlc_position"].get_spatial_series().timestamps),
+            name="time",
+        )
         COLUMNS = [
             "position_x",
             "position_y",
@@ -254,13 +288,16 @@ class DLCCentroid(dj.Computed):
             "velocity_y",
             "speed",
         ]
-        return pd.concat(
-            [
-                nwb_data["centroid"].set_index("time"),
-                nwb_data["velocity"].set_index("time"),
-            ],
-            axis=1,
-            keys=COLUMNS,
+        return pd.DataFrame(
+            np.concatenate(
+                (
+                    np.asarray(nwb_data["dlc_position"].get_spatial_series().data),
+                    np.asarray(nwb_data["dlc_velocity"].time_series["velocity"].data),
+                ),
+                axis=1,
+            ),
+            columns=COLUMNS,
+            index=index,
         )
 
 
@@ -314,18 +351,20 @@ def four_led_centroid(pos_df: pd.DataFrame, **params):
     all_good_mask = reduce(
         np.logical_and, (~green_nans, ~red_C_nans, ~red_L_nans, ~red_R_nans)
     )
-    centroid[all_good_mask] = (
-        (
-            pos_df.loc[idx[all_good_mask], idx[red_led_C, "x"]]
-            + pos_df.loc[idx[all_good_mask], idx[green_led, "x"]]
+    centroid[all_good_mask] = [
+        *zip(
+            (
+                pos_df.loc[idx[all_good_mask], idx[red_led_C, "x"]]
+                + pos_df.loc[idx[all_good_mask], idx[green_led, "x"]]
+            )
+            / 2,
+            (
+                pos_df.loc[idx[all_good_mask], idx[red_led_C, "y"]]
+                + pos_df.loc[idx[all_good_mask], idx[green_led, "y"]]
+            )
+            / 2,
         )
-        / 2,
-        (
-            pos_df.loc[idx[all_good_mask], idx[red_led_C, "y"]]
-            + pos_df.loc[idx[all_good_mask], idx[green_led, "y"]]
-        )
-        / 2,
-    )
+    ]
     # If all given LEDs are NaN
     all_bad_mask = reduce(
         np.logical_and, (green_nans, red_C_nans, red_L_nans, red_R_nans)
@@ -333,107 +372,124 @@ def four_led_centroid(pos_df: pd.DataFrame, **params):
     centroid[all_bad_mask, :] = np.nan
     # If green LED is NaN, but red center LED is not
     no_green_red_C = np.logical_and(green_nans, ~red_C_nans)
-    centroid[no_green_red_C] = [
-        *zip(
-            pos_df.loc[idx[no_green_red_C], idx[red_led_C, "x"]],
-            pos_df.loc[idx[no_green_red_C], idx[red_led_C, "y"]],
-        )
-    ]
+    if np.sum(no_green_red_C) > 0:
+        centroid[no_green_red_C] = [
+            *zip(
+                pos_df.loc[idx[no_green_red_C], idx[red_led_C, "x"]],
+                pos_df.loc[idx[no_green_red_C], idx[red_led_C, "y"]],
+            )
+        ]
     # If green and red center LEDs are NaN, but red left and red right LEDs are not
     no_green_no_red_C_red_L_red_R = reduce(
         np.logical_and, (green_nans, red_C_nans, ~red_L_nans, ~red_R_nans)
     )
-    centroid[no_green_no_red_C_red_L_red_R] = [
-        *zip(
-            (
-                pos_df.loc[idx[no_green_no_red_C_red_L_red_R], idx[red_led_L, "x"]]
-                + pos_df.loc[idx[no_green_no_red_C_red_L_red_R], idx[red_led_R, "x"]]
+    if np.sum(no_green_no_red_C_red_L_red_R) > 0:
+        centroid[no_green_no_red_C_red_L_red_R] = [
+            *zip(
+                (
+                    pos_df.loc[idx[no_green_no_red_C_red_L_red_R], idx[red_led_L, "x"]]
+                    + pos_df.loc[
+                        idx[no_green_no_red_C_red_L_red_R], idx[red_led_R, "x"]
+                    ]
+                )
+                / 2,
+                (
+                    pos_df.loc[idx[no_green_no_red_C_red_L_red_R], idx[red_led_L, "y"]]
+                    + pos_df.loc[
+                        idx[no_green_no_red_C_red_L_red_R], idx[red_led_R, "y"]
+                    ]
+                )
+                / 2,
             )
-            / 2,
-            (
-                pos_df.loc[idx[no_green_no_red_C_red_L_red_R], idx[red_led_L, "y"]]
-                + pos_df.loc[idx[no_green_no_red_C_red_L_red_R], idx[red_led_R, "y"]]
-            )
-            / 2,
-        )
-    ]
+        ]
     # If red center LED is NaN, but green, red left, and right LEDs are not
     green_red_L_red_R_no_red_C = reduce(
         np.logical_and, (~green_nans, red_C_nans, ~red_L_nans, ~red_R_nans)
     )
-    midpoint = (
-        (
-            pos_df.loc[idx[green_red_L_red_R_no_red_C], idx[red_led_L, "x"]]
-            + pos_df.loc[idx[green_red_L_red_R_no_red_C], idx[red_led_R, "x"]]
-        )
-        / 2,
-        (
-            pos_df.loc[idx[green_red_L_red_R_no_red_C], idx[red_led_L, "y"]]
-            + pos_df.loc[idx[green_red_L_red_R_no_red_C], idx[red_led_R, "y"]]
-        )
-        / 2,
-    )
-    centroid[green_red_L_red_R_no_red_C] = [
-        *zip(
+    if np.sum(green_red_L_red_R_no_red_C) > 0:
+        midpoint = (
             (
-                midpoint[0]
-                + pos_df.loc[idx[green_red_L_red_R_no_red_C], idx[green_led, "x"]]
+                pos_df.loc[idx[green_red_L_red_R_no_red_C], idx[red_led_L, "x"]]
+                + pos_df.loc[idx[green_red_L_red_R_no_red_C], idx[red_led_R, "x"]]
             )
             / 2,
             (
-                midpoint[1]
-                + pos_df.loc[idx[green_red_L_red_R_no_red_C], idx[green_led, "y"]]
+                pos_df.loc[idx[green_red_L_red_R_no_red_C], idx[red_led_L, "y"]]
+                + pos_df.loc[idx[green_red_L_red_R_no_red_C], idx[red_led_R, "y"]]
             )
             / 2,
         )
-    ]
+        centroid[green_red_L_red_R_no_red_C] = [
+            *zip(
+                (
+                    midpoint[0]
+                    + pos_df.loc[idx[green_red_L_red_R_no_red_C], idx[green_led, "x"]]
+                )
+                / 2,
+                (
+                    midpoint[1]
+                    + pos_df.loc[idx[green_red_L_red_R_no_red_C], idx[green_led, "y"]]
+                )
+                / 2,
+            )
+        ]
     # If red center and left LED is NaN, but green and red right LED are not
     green_red_R_no_red_C_no_red_L = reduce(
         np.logical_and, (~green_nans, red_C_nans, red_L_nans, ~red_R_nans)
     )
-    centroid[green_red_R_no_red_C_no_red_L] = [
-        *zip(
-            (
-                pos_df.loc[idx[green_red_R_no_red_C_no_red_L], idx[red_led_R, "x"]]
-                + pos_df.loc[idx[green_red_R_no_red_C_no_red_L], idx[green_led, "x"]]
+    if np.sum(green_red_R_no_red_C_no_red_L) > 0:
+        centroid[green_red_R_no_red_C_no_red_L] = [
+            *zip(
+                (
+                    pos_df.loc[idx[green_red_R_no_red_C_no_red_L], idx[red_led_R, "x"]]
+                    + pos_df.loc[
+                        idx[green_red_R_no_red_C_no_red_L], idx[green_led, "x"]
+                    ]
+                )
+                / 2,
+                (
+                    pos_df.loc[idx[green_red_R_no_red_C_no_red_L], idx[red_led_R, "y"]]
+                    + pos_df.loc[
+                        idx[green_red_R_no_red_C_no_red_L], idx[green_led, "y"]
+                    ]
+                )
+                / 2,
             )
-            / 2,
-            (
-                pos_df.loc[idx[green_red_R_no_red_C_no_red_L], idx[red_led_R, "y"]]
-                + pos_df.loc[idx[green_red_R_no_red_C_no_red_L], idx[green_led, "y"]]
-            )
-            / 2,
-        )
-    ]
+        ]
     # If red center and right LED is NaN, but green and red left LED are not
     green_red_L_no_red_C_no_red_R = reduce(
         np.logical_and, (~green_nans, red_C_nans, ~red_L_nans, red_R_nans)
     )
-    centroid[green_red_L_no_red_C_no_red_R] = [
-        *zip(
-            (
-                pos_df.loc[idx[green_red_L_no_red_C_no_red_R], idx[red_led_L, "x"]]
-                + pos_df.loc[idx[green_red_L_no_red_C_no_red_R], idx[green_led, "x"]]
+    if np.sum(green_red_L_no_red_C_no_red_R) > 0:
+        centroid[green_red_L_no_red_C_no_red_R] = [
+            *zip(
+                (
+                    pos_df.loc[idx[green_red_L_no_red_C_no_red_R], idx[red_led_L, "x"]]
+                    + pos_df.loc[
+                        idx[green_red_L_no_red_C_no_red_R], idx[green_led, "x"]
+                    ]
+                )
+                / 2,
+                (
+                    pos_df.loc[idx[green_red_L_no_red_C_no_red_R], idx[red_led_L, "y"]]
+                    + pos_df.loc[
+                        idx[green_red_L_no_red_C_no_red_R], idx[green_led, "y"]
+                    ]
+                )
+                / 2,
             )
-            / 2,
-            (
-                pos_df.loc[idx[green_red_L_no_red_C_no_red_R], idx[red_led_L, "y"]]
-                + pos_df.loc[idx[green_red_L_no_red_C_no_red_R], idx[green_led, "y"]]
-            )
-            / 2,
-        )
-    ]
+        ]
     # If all red LEDs are NaN, but green LED is not
     green_no_red = reduce(
         np.logical_and, (~green_nans, red_C_nans, red_L_nans, red_R_nans)
     )
-    centroid[green_no_red] = [
-        *zip(
-            pos_df.loc[idx[green_no_red], idx[green_led, "x"]],
-            pos_df.loc[idx[green_no_red], idx[green_led, "y"]],
-        )
-    ]
-
+    if np.sum(green_no_red) > 0:
+        centroid[green_no_red] = [
+            *zip(
+                pos_df.loc[idx[green_no_red], idx[green_led, "x"]],
+                pos_df.loc[idx[green_no_red], idx[green_led, "y"]],
+            )
+        ]
     return centroid
 
 
@@ -483,23 +539,26 @@ def two_pt_centroid(pos_df: pd.DataFrame, **params):
     ]
     # If only point1 is good
     pt1_mask = np.logical_and(~pt1_nans, pt2_nans)
-    centroid[pt1_mask] = [
-        *zip(
-            pos_df.loc[idx[pt1_mask], idx[PT1, "x"]],
-            pos_df.loc[idx[pt1_mask], idx[PT1, "y"]],
-        )
-    ]
+    if np.sum(pt1_mask) > 0:
+        centroid[pt1_mask] = [
+            *zip(
+                pos_df.loc[idx[pt1_mask], idx[PT1, "x"]],
+                pos_df.loc[idx[pt1_mask], idx[PT1, "y"]],
+            )
+        ]
     # If only point2 is good
     pt2_mask = np.logical_and(pt1_nans, ~pt2_nans)
-    centroid[pt2_mask] = [
-        *zip(
-            pos_df.loc[idx[pt2_mask], idx[PT2, "x"]],
-            pos_df.loc[idx[pt2_mask], idx[PT2, "y"]],
-        )
-    ]
+    if np.sum(pt2_mask) > 0:
+        centroid[pt2_mask] = [
+            *zip(
+                pos_df.loc[idx[pt2_mask], idx[PT2, "x"]],
+                pos_df.loc[idx[pt2_mask], idx[PT2, "y"]],
+            )
+        ]
     # If neither point is not NaN
     all_bad_mask = np.logical_and(pt1_nans, pt2_nans)
-    centroid[all_bad_mask, :] = np.nan
+    if np.sum(all_bad_mask) > 0:
+        centroid[all_bad_mask, :] = np.nan
 
     return centroid
 

--- a/spyglass_dlc/dgramling_dlc_centroid.py
+++ b/spyglass_dlc/dgramling_dlc_centroid.py
@@ -254,6 +254,14 @@ class DLCCentroid(dj.Computed):
             comments=spatial_series.comments,
             description="x_velocity, y_velocity, speed",
         )
+        velocity.create_timeseries(
+            name="video_frame_ind",
+            unit="index",
+            timestamps=final_df.index.to_numpy(),
+            data=pos_df[pos_df.columns.levels[0][0]].video_frame_ind.to_numpy(),
+            description="video_frame_ind",
+            comments="no comments",
+        )
         # Add to Analysis NWB file
         key["analysis_file_name"] = AnalysisNwbfile().create(key["nwb_file_name"])
         nwb_analysis_file = AnalysisNwbfile()
@@ -282,6 +290,7 @@ class DLCCentroid(dj.Computed):
             name="time",
         )
         COLUMNS = [
+            "video_frame_ind",
             "position_x",
             "position_y",
             "velocity_x",
@@ -291,6 +300,10 @@ class DLCCentroid(dj.Computed):
         return pd.DataFrame(
             np.concatenate(
                 (
+                    np.asarray(
+                        nwb_data["dlc_velocity"].time_series["video_frame_ind"].data,
+                        dtype=int,
+                    )[:, np.newaxis],
                     np.asarray(nwb_data["dlc_position"].get_spatial_series().data),
                     np.asarray(nwb_data["dlc_velocity"].time_series["velocity"].data),
                 ),

--- a/spyglass_dlc/dgramling_dlc_cohort.py
+++ b/spyglass_dlc/dgramling_dlc_cohort.py
@@ -1,16 +1,4 @@
-import numpy as np
-import pandas as pd
-import math
 import datajoint as dj
-from datetime import datetime
-import pynwb
-import os
-import sys
-from itertools import groupby
-from operator import itemgetter
-import bottleneck as bn
-from typing import List, Dict, OrderedDict
-from pathlib import Path
 from spyglass.common.dj_helper_fn import fetch_nwb
 from spyglass.common.common_nwbfile import AnalysisNwbfile
 from spyglass.common.common_interval import IntervalList
@@ -27,13 +15,17 @@ class DLCSmoothInterpCohortSelection(dj.Manual):
     get combined into a cohort
     """
 
+    # TODO: try to make a strict dependence on DLCSmoothInterpSelection
     definition = """
     -> IntervalList
     dlc_si_cohort_selection_name : varchar(120)
     ---
-    -> DLCSmoothInterp
-    bodyparts : blob
-
+    epoch                   : int           # the session epoch for this task and apparatus(1 based)
+    video_file_num          : int
+    dlc_model_name          : varchar(64)   # User-friendly model name
+    dlc_model_params_name   : varchar(40)   
+    dlc_si_params_name      : varchar(80)   # descriptive name of this interval list
+    bodyparts               : blob          # List of bodyparts to include in cohort
     """
 
 

--- a/spyglass_dlc/dgramling_dlc_cohort.py
+++ b/spyglass_dlc/dgramling_dlc_cohort.py
@@ -1,7 +1,7 @@
 import datajoint as dj
 from spyglass.common.dj_helper_fn import fetch_nwb
 from spyglass.common.common_nwbfile import AnalysisNwbfile
-from spyglass.common.common_interval import IntervalList
+from .dgramling_dlc_pose_estimation import DLCPoseEstimation
 from .dgramling_dlc_position import DLCSmoothInterp
 from .dgramling_dlc_project import BodyPart
 
@@ -17,13 +17,9 @@ class DLCSmoothInterpCohortSelection(dj.Manual):
 
     # TODO: try to make a strict dependence on DLCSmoothInterpSelection
     definition = """
-    -> IntervalList
     dlc_si_cohort_selection_name : varchar(120)
+    -> DLCPoseEstimation
     ---
-    epoch                   : int           # the session epoch for this task and apparatus(1 based)
-    video_file_num          : int
-    dlc_model_name          : varchar(64)   # User-friendly model name
-    dlc_model_params_name   : varchar(40)   
     dlc_si_params_name      : varchar(80)   # descriptive name of this interval list
     bodyparts               : blob          # List of bodyparts to include in cohort
     """

--- a/spyglass_dlc/dgramling_dlc_model.py
+++ b/spyglass_dlc/dgramling_dlc_model.py
@@ -63,12 +63,13 @@ class DLCModelSource(dj.Manual):
         """
 
     @classmethod
-    @accepts(None, None, ("FromUpstream", "FromImport"))
+    @accepts(None, None, ("FromUpstream", "FromImport"), None)
     def insert_entry(
         cls,
         dlc_model_name: str,
         project_name: str,
         source: str = "FromUpstream",
+        key: dict = None,
         **kwargs,
     ):
 
@@ -83,6 +84,7 @@ class DLCModelSource(dj.Manual):
                 "dlc_model_name": dlc_model_name,
                 "project_name": project_name,
                 "project_path": project_path,
+                **key,
             },
             **kwargs,
         )

--- a/spyglass_dlc/dgramling_dlc_model.py
+++ b/spyglass_dlc/dgramling_dlc_model.py
@@ -1,21 +1,12 @@
 from pathlib import Path, PosixPath, PurePath
 import os
-import sys
 import glob
-from typing import List, Dict, OrderedDict
-import numpy as np
-import pandas as pd
 import datajoint as dj
-from datajoint.errors import DataJointError
 import ruamel.yaml as yaml
 from spyglass.common.common_lab import LabTeam
 from .dgramling_dlc_project import BodyPart, DLCProject
 from .dgramling_dlc_training import DLCModelTraining, DLCModelTrainingParams
 from .dlc_decorators import accepts
-from .dlc_utils import (
-    find_full_path,
-    get_dlc_root_data_dir,
-)
 from . import dlc_reader
 
 schema = dj.schema("dgramling_dlc_model")

--- a/spyglass_dlc/dgramling_dlc_orient.py
+++ b/spyglass_dlc/dgramling_dlc_orient.py
@@ -1,10 +1,6 @@
 import numpy as np
 import pandas as pd
 import datajoint as dj
-import pynwb
-import os
-import sys
-import bottleneck as bn
 from typing import List, Dict, OrderedDict
 from pathlib import Path
 from position_tools.core import gaussian_smooth
@@ -81,7 +77,7 @@ class DLCOrientation(dj.Computed):
         )
         dt = np.median(np.diff(pos_df["time"]))
         sampling_rate = 1 / dt
-        orient_func = _key_to_func_dict(params["orient_method"])
+        orient_func = _key_to_func_dict[params["orient_method"]]
         orientation = orient_func(pos_df, **params)
         # Smooth orientation
         is_nan = np.isnan(orientation)

--- a/spyglass_dlc/dgramling_dlc_orient.py
+++ b/spyglass_dlc/dgramling_dlc_orient.py
@@ -14,7 +14,9 @@ schema = dj.schema("dgramling_dlc_orient")
 
 @schema
 class DLCOrientationParams(dj.Manual):
-    """Parameters for calculating the centroid"""
+    """
+    Parameters for determining and smoothing the orientation of a set of BodyParts
+    """
 
     definition = """
     dlc_orientation_params_name: varchar(80) # name for this set of parameters
@@ -54,7 +56,9 @@ class DLCOrientationSelection(dj.Manual):
 
 @schema
 class DLCOrientation(dj.Computed):
-    """ """
+    """
+    Determines and smooths orientation of a set of bodyparts given a specified method
+    """
 
     definition = """
     -> DLCOrientationSelection

--- a/spyglass_dlc/dgramling_dlc_orient.py
+++ b/spyglass_dlc/dgramling_dlc_orient.py
@@ -75,7 +75,7 @@ class DLCOrientation(dj.Computed):
         orientation_smoothing_std_dev = params.pop(
             "orientation_smoothing_std_dev", None
         )
-        dt = np.median(np.diff(pos_df["time"]))
+        dt = np.median(np.diff(pos_df.index.to_numpy()))
         sampling_rate = 1 / dt
         orient_func = _key_to_func_dict[params["orient_method"]]
         orientation = orient_func(pos_df, **params)

--- a/spyglass_dlc/dgramling_dlc_pose_estimation.py
+++ b/spyglass_dlc/dgramling_dlc_pose_estimation.py
@@ -205,6 +205,7 @@ class DLCPoseEstimation(dj.Computed):
                     }
                 )
         for body_part, part_df in body_parts_df.items():
+            key["bodypart"] = body_part
             key["analysis_file_name"] = AnalysisNwbfile().create(key["nwb_file_name"])
             nwb_analysis_file = AnalysisNwbfile()
             key["dlc_pose_estimation_object_id"] = nwb_analysis_file.add_nwb_object(
@@ -228,45 +229,3 @@ class DLCPoseEstimation(dj.Computed):
             },
             axis=1,
         )
-
-    # @classmethod
-    # def get_trajectory(cls, key, body_parts="all"):
-    #     """Returns a pandas dataframe of coordinates of the specified body_part(s)
-
-    #     Parameters
-    #     ----------
-    #     key: A DataJoint query specifying one PoseEstimation entry. body_parts:
-    #     Optional. Body parts as a list. If "all", all joints
-
-    #     Returns
-    #     -------
-    #     df: multi index pandas dataframe with DLC scorer names, body_parts
-    #         and x/y coordinates of each joint name for a camera_id, similar to output of
-    #         DLC dataframe. If 2D, z is set of zeros
-    #     """
-    #     import pandas as pd
-
-    #     model_name = key["model_name"]
-
-    #     if body_parts == "all":
-    #         body_parts = (cls.BodyPart & key).fetch("body_part")
-    #     else:
-    #         body_parts = list(body_parts)
-
-    #     df = None
-    #     for body_part in body_parts:
-    #         x_pos, y_pos, z_pos, likelihood = (
-    #             cls.BodyPart & {"body_part": body_part}
-    #         ).fetch1("x_pos", "y_pos", "z_pos", "likelihood")
-    #         if not z_pos:
-    #             z_pos = np.zeros_like(x_pos)
-
-    #         a = np.vstack((x_pos, y_pos, z_pos, likelihood))
-    #         a = a.T
-    #         pdindex = pd.MultiIndex.from_product(
-    #             [[model_name], [body_part], ["x", "y", "z", "likelihood"]],
-    #             names=["scorer", "bodyparts", "coords"],
-    #         )
-    #         frame = pd.DataFrame(a, columns=pdindex, index=range(0, a.shape[0]))
-    #         df = pd.concat([df, frame], axis=1)
-    #     return df

--- a/spyglass_dlc/dgramling_dlc_position.py
+++ b/spyglass_dlc/dgramling_dlc_position.py
@@ -51,6 +51,13 @@ class DLCSmoothInterpParams(dj.Manual):
             skip_duplicates=True,
         )
 
+    @classmethod
+    def get_default(cls):
+        return (cls & {"dlc_si_params_name": "default"}).fetch1("params")
+
+    def delete(self, key, **kwargs):
+        super().delete(key, **kwargs)
+
 
 @schema
 class DLCSmoothInterpSelection(dj.Manual):
@@ -66,6 +73,11 @@ class DLCSmoothInterpSelection(dj.Manual):
 
 @schema
 class DLCSmoothInterp(dj.Computed):
+    """
+    Interpolates across low likelihood periods and smooths the position
+    Can take a few minutes.
+    """
+
     definition = """
     -> DLCSmoothInterpSelection
     ---
@@ -74,21 +86,24 @@ class DLCSmoothInterp(dj.Computed):
     """
 
     def make(self, key):
-        key["analysis_file_name"] = AnalysisNwbfile().create(key["nwb_file_name"])
         # Get labels to smooth from Parameters table
-        params = (DLCSmoothInterpParams() & key).fetch1()
-        max_plausible_speed = params["params"].pop("max_plausible_speed")
-        speed_smoothing_std_dev = params["params"].pop("speed_smoothing_std_dev")
-        sampling_rate = params["params"].pop("sampling_rate")
+        params = (DLCSmoothInterpParams() & key).fetch1("params")
+        max_plausible_speed = params.pop("max_plausible_speed")
+        speed_smoothing_std_dev = params.pop("speed_smoothing_std_dev")
+        sampling_rate = params.pop("sampling_rate")
         # Get DLC output dataframe
-        dlc_df = (DLCPoseEstimation.BodyPart() & key).fetch1_dataframe()[0]
+        print("fetching Pose Estimation Dataframe")
+        dlc_df = (DLCPoseEstimation.BodyPart() & key).fetch1_dataframe()
+        print("converting to cm")
         dlc_df = convert_to_cm(dlc_df, key)
+        print("adding timestamps to DataFrame")
         dlc_df = add_timestamps(dlc_df, key)
         # Calculate speed
         idx = pd.IndexSlice
+        print("Calculating speed")
         LED_speed = get_speed(
             dlc_df.loc[:, idx[("x", "y")]],
-            dlc_df["time"],
+            dlc_df.index.to_numpy(),
             sigma=speed_smoothing_std_dev,
             sampling_frequency=sampling_rate,
         )
@@ -96,13 +111,18 @@ class DLCSmoothInterp(dj.Computed):
         is_too_fast = LED_speed > max_plausible_speed
         dlc_df.loc[idx[is_too_fast], idx[("x", "y")]] = np.nan
         # Interpolate the NaN points
-        dlc_df.loc[:, idx[("x", "y")]] = interpolate_nan(dlc_df.loc[:, idx[("x", "y")]])
+        dlc_df.loc[:, idx[("x", "y")]] = interpolate_nan(
+            position=dlc_df.loc[:, idx[("x", "y")]].to_numpy(),
+            time=dlc_df.index.to_numpy(),
+        )
         # get interpolated points
+        print("interpolating across low likelihood times")
         interp_df = interp_pos(dlc_df, **params["interp_params"])
         if "smoothing_duration" in params["smoothing_params"]:
             smoothing_duration = params["smoothing_params"].pop("smoothing_duration")
-        dt = np.median(np.diff(dlc_df["time"]))
+        dt = np.median(np.diff(dlc_df.index.to_numpy()))
         sampling_rate = 1 / dt
+        print("smoothing position")
         smooth_df = smooth_pos(
             interp_df,
             smoothing_duration=smoothing_duration,
@@ -110,7 +130,7 @@ class DLCSmoothInterp(dj.Computed):
             **params["smoothing_params"],
         )
         final_df = smooth_df.drop(["likelihood"], axis=1)
-
+        key["analysis_file_name"] = AnalysisNwbfile().create(key["nwb_file_name"])
         # Add dataframe to AnalysisNwbfile
         nwb_analysis_file = AnalysisNwbfile()
         key["dlc_smooth_interp_object_id"] = nwb_analysis_file.add_nwb_object(
@@ -121,6 +141,7 @@ class DLCSmoothInterp(dj.Computed):
             nwb_file_name=key["nwb_file_name"],
             analysis_file_name=key["analysis_file_name"],
         )
+        self.insert1(key)
 
     def fetch_nwb(self, *attrs, **kwargs):
         return fetch_nwb(
@@ -195,20 +216,20 @@ def interp_pos(dlc_df, **kwargs):
                         dlc_df.loc[idx[span_start:span_stop], idx["y"]] = np.nan
                         print(f"ind: {ind} length: {span_len} " f"not interpolated")
                         continue
-        start_time = dlc_df["time"].iloc[span_start]
-        stop_time = dlc_df["time"].iloc[span_stop]
+        start_time = dlc_df.index[span_start]
+        stop_time = dlc_df.index[span_stop]
         xnew = np.interp(
-            x=dlc_df["time"].iloc[span_start : span_stop + 1],
+            x=dlc_df.index[span_start : span_stop + 1],
             xp=[start_time, stop_time],
             fp=[x[0], x[-1]],
         )
         ynew = np.interp(
-            x=dlc_df["time"].iloc[span_start : span_stop + 1],
+            x=dlc_df.index[span_start : span_stop + 1],
             xp=[start_time, stop_time],
             fp=[y[0], y[-1]],
         )
-        dlc_df.loc[idx[span_start:span_stop], idx["x"]] = xnew
-        dlc_df.loc[idx[span_start:span_stop], idx["y"]] = ynew
+        dlc_df.loc[idx[start_time:stop_time], idx["x"]] = xnew
+        dlc_df.loc[idx[start_time:stop_time], idx["y"]] = ynew
     return dlc_df
 
 

--- a/spyglass_dlc/dgramling_dlc_position.py
+++ b/spyglass_dlc/dgramling_dlc_position.py
@@ -1,9 +1,8 @@
+from itertools import groupby
+from operator import itemgetter
 import numpy as np
 import pandas as pd
 import datajoint as dj
-from datetime import datetime
-from itertools import groupby
-from operator import itemgetter
 import bottleneck as bn
 from position_tools import (
     get_speed,
@@ -73,8 +72,8 @@ class DLCSmoothInterpParams(dj.Manual):
     def get_default(cls):
         return (cls & {"dlc_si_params_name": "default"}).fetch1("params")
 
-    def delete(self, key, **kwargs):
-        super().delete(key, **kwargs)
+    # def delete(self, key, **kwargs):
+    #     super().delete(key, **kwargs)
 
 
 @schema

--- a/spyglass_dlc/dgramling_dlc_position.py
+++ b/spyglass_dlc/dgramling_dlc_position.py
@@ -20,7 +20,25 @@ schema = dj.schema("dgramling_dlc_position")
 
 @schema
 class DLCSmoothInterpParams(dj.Manual):
-    """Parameters for extracting the smoothed head position."""
+    """
+     Parameters for extracting the smoothed head position.
+
+    Parameters
+    ----------
+    smoothing_params : dict
+        smoothing_duration : float, default 0.05
+            number of frames to smooth over: sampling_rate*smoothing_duration = num_frames
+    interp_params : dict
+        likelihood_thresh : float, default 0.95
+            likelihood below which to NaN and interpolate over
+    sampling_rate : int
+        sampling rate of the recording
+    max_plausible_speed : float, default 300.0
+        fastest possible speed (m/s) bodypart could move,
+        above which is NaN
+    speed_smoothing_std_dev : float, default 0.1
+        standard deviation of gaussian kernel to smooth speed
+    """
 
     definition = """
     dlc_si_params_name : varchar(80) # name for this set of parameters
@@ -130,6 +148,7 @@ class DLCSmoothInterp(dj.Computed):
             **params["smoothing_params"],
         )
         final_df = smooth_df.drop(["likelihood"], axis=1)
+        final_df = final_df.rename_axis("time").reset_index()
         key["analysis_file_name"] = AnalysisNwbfile().create(key["nwb_file_name"])
         # Add dataframe to AnalysisNwbfile
         nwb_analysis_file = AnalysisNwbfile()

--- a/spyglass_dlc/dgramling_dlc_project.py
+++ b/spyglass_dlc/dgramling_dlc_project.py
@@ -4,7 +4,7 @@ import os
 import glob
 import ruamel.yaml
 from itertools import combinations
-from typing import List, Dict, OrderedDict
+from typing import List
 from pathlib import Path
 from spyglass.common.common_lab import LabTeam
 from .dlc_utils import _convert_mp4
@@ -168,15 +168,12 @@ class DLCProject(dj.Manual):
             (Default is None) list of video names to extract frames from
             If not None, will limit videos within video_path to use
         """
-
         skeleton_node = None
+        # TODO: this needs to be cleaned up
         if convert_video:
-            raise NotImplementedError(f"argument `convert_video` has yet to be tested")
-            videos_to_convert = glob.glob(video_path + "*.h264")
-            (
-                _convert_mp4(video, video_path, video_path, "mp4")
-                for video in videos_to_convert
-            )
+            from .dlc_utils import check_videofile
+
+            check_videofile(video_path=video_path, output_path=video_path)
         videos = glob.glob(video_path + "*.mp4")
         if len(videos) < 1:
             raise ValueError(f"no .mp4 videos found in{video_path}")
@@ -197,12 +194,11 @@ class DLCProject(dj.Manual):
         for bodypart in bodyparts:
             if not bool(BodyPart() & {"bodypart": bodypart}):
                 raise ValueError(f"bodypart: {bodypart} not found in BodyPart table")
+        config_kwargs = {"numframes2pick": frames_per_video, "dotsize": 3}.update(
+            kwargs
+        )
         add_to_config(
-            config_path,
-            bodyparts,
-            skeleton_node=skeleton_node,
-            numframes2pick=frames_per_video,
-            dotsize=3,
+            config_path, bodyparts, skeleton_node=skeleton_node, **config_kwargs
         )
         key = {
             "project_name": project_name,

--- a/spyglass_dlc/dgramling_dlc_project.py
+++ b/spyglass_dlc/dgramling_dlc_project.py
@@ -1,13 +1,16 @@
+import stat
+import glob
+import shutil
+import os
+from itertools import combinations
+from typing import List, Dict
+from pathlib import Path
+import getpass
+import ruamel.yaml
 import numpy as np
 import datajoint as dj
-import os
-import glob
-import ruamel.yaml
-from itertools import combinations
-from typing import List
-from pathlib import Path
 from spyglass.common.common_lab import LabTeam
-from .dlc_utils import _convert_mp4
+from .dlc_utils import check_videofile, _set_permissions, get_video_path
 
 
 schema = dj.schema("dgramling_dlc_project")
@@ -31,13 +34,15 @@ class DLCProject(dj.Manual):
     With ability to edit config, extract frames, label frames
     """
 
+    # Add more parameters as secondary keys...
+    # TODO: collapse params into blob dict
     definition = """
     project_name     : varchar(100) # name of DLC project
     ---
     -> LabTeam
     bodyparts        : blob         # list of bodyparts to label
     frames_per_video : int          # number of frames to extract from each video
-    config_path      : varchar(120) # path to config.yaml for model
+    config_path      : varchar(120) # path to config.yaml for model 
     """
 
     class BodyPart(dj.Part):
@@ -64,8 +69,6 @@ class DLCProject(dj.Manual):
         assert (
             key["project_name"] not in project_names_in_use
         ), f"project name: {key['project_name']} is already in use."
-        if not bool(LabTeam() & {"team_name": key["team_name"]}):
-            raise ValueError(f"team_name: {key['team_name']} does not exist in LabTeam")
         assert isinstance(
             key["frames_per_video"], int
         ), "frames_per_video must be of type `int`"
@@ -113,7 +116,18 @@ class DLCProject(dj.Manual):
         if frames_per_video:
             if frames_per_video != cfg["numframes2pick"]:
                 add_to_config(config_path, **{"numframes2pick": frames_per_video})
-
+        project_path = Path(config_path).parent
+        dlc_project_path = os.environ["DLC_PROJECT_PATH"]
+        if dlc_project_path not in project_path.as_posix():
+            project_dirname = project_path.name
+            new_proj_dir = shutil.copytree(
+                src=project_path, dst=f"{dlc_project_path}/{project_dirname}/"
+            )
+            new_config_path = Path(new_proj_dir / "config.yaml")
+            assert new_config_path.exists(), "config.yaml did not copy to new location"
+            config_path = new_config_path
+            add_to_config(config_path, **{"project_path": new_proj_dir})
+        # TODO still need to copy videos over to video dir
         key = {
             "project_name": project_name,
             "team_name": lab_team,
@@ -138,10 +152,10 @@ class DLCProject(dj.Manual):
         bodyparts: List,
         lab_team: str,
         frames_per_video: int,
-        video_path: str,
-        project_directory: str = "cumulus/deeplabcut/",
-        convert_video=False,
-        video_names: List = None,
+        video_list: List,
+        project_directory: str = os.environ["DLC_PROJECT_PATH"],
+        output_path: str = os.environ["DLC_VIDEO_PATH"],
+        set_permissions=False,
         **kwargs,
     ):
         """
@@ -159,28 +173,54 @@ class DLCProject(dj.Manual):
             (Default is '/cumulus/deeplabcut/')
         frames_per_video : int
             number of frames to extract from each video
-        video_path : str
-            directory where videos to create model from are stored
-        convert_video : bool
-            if True will convert videos in video_path to .MP4 format from .h264
+        video_list : list
+            list of dicts of form [{'nwb_file_name': nwb_file_name, 'epoch': epoch #},...]
+            to query VideoFile table for videos to train on.
+            Can also be list of absolute paths to import videos from
+        output_path : str
+            target path to output converted videos
+            (Default is '/nimbus/deeplabcut/videos/')
+        set_permissions : bool
+            if True, will set permissions for user and group to be read+write
             (Default is False)
-        video_names : list
-            (Default is None) list of video names to extract frames from
-            If not None, will limit videos within video_path to use
         """
+        add_to_files = kwargs.pop("add_to_files", True)
+        if not bool(LabTeam() & {"team_name": lab_team}):
+            raise ValueError(f"team_name: {lab_team} does not exist in LabTeam")
         skeleton_node = None
-        # TODO: this needs to be cleaned up
-        if convert_video:
-            from .dlc_utils import check_videofile
-
-            check_videofile(video_path=video_path, output_path=video_path)
-        videos = glob.glob(video_path + "*.mp4")
-        if len(videos) < 1:
-            raise ValueError(f"no .mp4 videos found in{video_path}")
-        if video_names:
+        # If dict, assume of form {'nwb_file_name': nwb_file_name, 'epoch': epoch}
+        # and pass to get_video_path to reference VideoFile table for path
+        if all(isinstance(n, Dict) for n in video_list):
+            videos_to_convert = [get_video_path(video_key) for video_key in video_list]
             videos = [
-                video for video in videos if any(map(video.__contains__, video_names))
+                check_videofile(
+                    video_path=video[0],
+                    output_path=output_path,
+                    video_filename=video[1],
+                )
+                for video in videos_to_convert
             ]
+        # If not dict, assume list of video file paths that may or may not need to be converted
+        else:
+            videos = []
+            if not all([Path(video).exists() for video in video_list]):
+                raise OSError("at least one file in video_list does not exist")
+            for video in video_list:
+                video_path = Path(video).parent
+                video_filename = video.rsplit(video_path.as_posix(), maxsplit=1)[
+                    -1
+                ].split("/")[-1]
+                videos.extend(
+                    [
+                        check_videofile(
+                            video_path=video_path,
+                            output_path=output_path,
+                            video_filename=video_filename,
+                        )[0].as_posix()
+                    ]
+                )
+            if len(videos) < 1:
+                raise ValueError(f"no .mp4 videos found in{video_path}")
         from deeplabcut import create_new_project
 
         config_path = create_new_project(
@@ -194,23 +234,38 @@ class DLCProject(dj.Manual):
         for bodypart in bodyparts:
             if not bool(BodyPart() & {"bodypart": bodypart}):
                 raise ValueError(f"bodypart: {bodypart} not found in BodyPart table")
-        config_kwargs = {"numframes2pick": frames_per_video, "dotsize": 3}.update(
-            kwargs
-        )
-        add_to_config(
-            config_path, bodyparts, skeleton_node=skeleton_node, **config_kwargs
-        )
+        kwargs.update({"numframes2pick": frames_per_video, "dotsize": 3})
+        add_to_config(config_path, bodyparts, skeleton_node=skeleton_node, **kwargs)
         key = {
             "project_name": project_name,
             "team_name": lab_team,
             "bodyparts": bodyparts,
             "config_path": config_path,
-            "numframes2pick": frames_per_video,
+            "frames_per_video": frames_per_video,
         }
-        if not os.path.exists(key["video_path"]):
-            raise OSError(f"{key['video_path']} does not exist")
+        # TODO: make permissions setting more flexible.
+        if set_permissions:
+            permissions = (
+                stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IWGRP | stat.S_IROTH
+            )
+            username = getpass.getuser()
+            if not groupname:
+                groupname = username
+            _set_permissions(
+                directory=project_directory,
+                mode=permissions,
+                username=username,
+                groupname=groupname,
+            )
         cls.insert1(key)
         cls.BodyPart.insert((project_name, bp) for bp in bodyparts)
+        if add_to_files:
+            del key["bodyparts"]
+            del key["team_name"]
+            del key["config_path"]
+            del key["frames_per_video"]
+            # Add videos to training files
+            cls.add_training_files(key)
 
     @classmethod
     def add_training_files(cls, key):
@@ -233,7 +288,7 @@ class DLCProject(dj.Manual):
                 )
             )
         for video in video_names:
-            key["file_name"] = f'video_{os.path.splitext(video.split("/")[-1])[0]}'
+            key["file_name"] = f'{os.path.splitext(video.split("/")[-1])[0]}'
             key["file_ext"] = os.path.splitext(video.split("/")[-1])[-1].split(".")[-1]
             key["file_path"] = video
             cls.File.insert1(key, skip_duplicates=True)

--- a/spyglass_dlc/dgramling_dlc_selection.py
+++ b/spyglass_dlc/dgramling_dlc_selection.py
@@ -1,33 +1,49 @@
+import matplotlib.pyplot as plt
+from pathlib import Path
 import numpy as np
 import pandas as pd
 import datajoint as dj
+from tqdm import tqdm as tqdm
 import pynwb
+import cv2
 from spyglass.common.dj_helper_fn import fetch_nwb
 from spyglass.common.common_nwbfile import AnalysisNwbfile
-from spyglass.common.common_behav import RawPosition
+from spyglass.common.common_behav import RawPosition, VideoFile
 from spyglass.common.common_interval import IntervalList
+from spyglass_dlc.dgramling_dlc_pose_estimation import (
+    DLCPoseEstimationSelection,
+    DLCPoseEstimation,
+)
+
+from spyglass_dlc.dlc_utils import get_video_path
 from .dgramling_dlc_centroid import DLCCentroid
 from .dgramling_dlc_orient import DLCOrientation
+from .dgramling_dlc_position import DLCSmoothInterp
+from .dgramling_dlc_cohort import DLCSmoothInterpCohort
 
 schema = dj.schema("dgramling_dlc_selection")
 
 
 @schema
 class DLCPosSelection(dj.Manual):
+    """
+    Specify collection of upstream DLCCentroid and DLCOrientation entries
+    to combine into a set of position information
+    """
+
     definition = """
     -> DLCCentroid.proj(dlc_si_cohort_centroid='dlc_si_cohort_selection_name', centroid_analysis_file_name='analysis_file_name')
     -> DLCOrientation.proj(dlc_si_cohort_orientation='dlc_si_cohort_selection_name', orientation_analysis_file_name='analysis_file_name')
     """
 
 
-"""
-Not sure this will work... would ideally combine centroid and orientation into single entry with single dataframe,
-but may be difficult to resolve primary keys if cohorts different
-"""
-
-
 @schema
 class DLCPos(dj.Computed):
+    """
+    Combines upstream DLCCentroid and DLCOrientation
+    entries into a single entry with a single Analysis NWB file
+    """
+
     definition = """
     -> DLCPosSelection
     ---
@@ -42,6 +58,9 @@ class DLCPos(dj.Computed):
         orientation_nwb_data = (DLCOrientation & key).fetch_nwb()[0]
         position_object = position_nwb_data["dlc_position"].spatial_series["position"]
         velocity_object = position_nwb_data["dlc_velocity"].time_series["velocity"]
+        video_frame_object = position_nwb_data["dlc_velocity"].time_series[
+            "video_frame_ind"
+        ]
         orientation_object = orientation_nwb_data["dlc_orientation"].spatial_series[
             "orientation"
         ]
@@ -75,10 +94,17 @@ class DLCPos(dj.Computed):
             comments=velocity_object.comments,
             description=velocity_object.description,
         )
+        velocity.create_timeseries(
+            name=video_frame_object.name,
+            unit=video_frame_object.unit,
+            timestamps=np.asarray(video_frame_object.timestamps),
+            data=np.asarray(video_frame_object.data),
+            description=video_frame_object.description,
+            comments=video_frame_object.comments,
+        )
         # Add to Analysis NWB file
         key["analysis_file_name"] = AnalysisNwbfile().create(key["nwb_file_name"])
         nwb_analysis_file = AnalysisNwbfile()
-
         key["orientation_object_id"] = nwb_analysis_file.add_nwb_object(
             key["analysis_file_name"], orientation
         )
@@ -108,6 +134,7 @@ class DLCPos(dj.Computed):
             name="time",
         )
         COLUMNS = [
+            "video_frame_ind",
             "position_x",
             "position_y",
             "orientation",
@@ -118,6 +145,10 @@ class DLCPos(dj.Computed):
         return pd.DataFrame(
             np.concatenate(
                 (
+                    np.asarray(
+                        nwb_data["velocity"].time_series["video_frame_ind"].data,
+                        dtype=int,
+                    )[:, np.newaxis],
                     np.asarray(nwb_data["position"].get_spatial_series().data),
                     np.asarray(nwb_data["orientation"].get_spatial_series().data)[
                         :, np.newaxis
@@ -129,3 +160,441 @@ class DLCPos(dj.Computed):
             columns=COLUMNS,
             index=index,
         )
+
+
+@schema
+class DLCPosVideo(dj.Computed):
+    """Creates a video of the computed head position and orientation as well as
+    the original LED positions overlayed on the video of the animal.
+
+    Use for debugging the effect of position extraction parameters."""
+
+    definition = """
+    -> DLCPos
+    ---
+    """
+
+    def make(self, key):
+        from tqdm import tqdm as tqdm
+
+        M_TO_CM = 100
+        epoch = (
+            int(
+                key["interval_list_name"]
+                .replace("pos ", "")
+                .replace(" valid times", "")
+            )
+            + 1
+        )
+        pose_estimation_key = {
+            "nwb_file_name": key["nwb_file_name"],
+            "interval_list_name": key["interval_list_name"],
+            "dlc_si_cohort_selection_name": key["dlc_si_cohort_centroid"],
+        }
+        pose_estimation_params, video_filename, output_dir = (
+            DLCPoseEstimationSelection() & pose_estimation_key
+        ).fetch1("pose_estimation_params", "video_path", "pose_estimation_output_dir")
+        meters_per_pixel = (DLCPoseEstimation() & pose_estimation_key).fetch1(
+            "meters_per_pixel"
+        )
+        crop = None
+        if "cropping" in pose_estimation_params:
+            crop = pose_estimation_params["cropping"]
+        print("Loading position data...")
+        position_info_df = (
+            DLCPos()
+            & {
+                "nwb_file_name": key["nwb_file_name"],
+                "interval_list_name": key["interval_list_name"],
+                "dlc_si_cohort_centroid": key["dlc_si_cohort_centroid"],
+                "dlc_centroid_params_name": key["dlc_centroid_params_name"],
+                "dlc_si_cohort_orientation": key["dlc_si_cohort_orientation"],
+                "dlc_orientation_params_name": key["dlc_orientation_params_name"],
+            }
+        ).fetch1_dataframe()
+        pose_estimation_df = pd.concat(
+            {
+                bodypart: (
+                    DLCPoseEstimation.BodyPart()
+                    & {**pose_estimation_key, **{"bodypart": bodypart}}
+                ).fetch1_dataframe()
+                for bodypart in (DLCSmoothInterpCohort.BodyPart & pose_estimation_key)
+                .fetch("bodypart")
+                .tolist()
+            },
+            axis=1,
+        )
+        assert len(pose_estimation_df) == len(position_info_df), (
+            f"length of pose_estimation_df: {len(pose_estimation_df)} "
+            f"does not match the length of position_info_df: {len(position_info_df)}."
+        )
+
+        nwb_base_filename = key["nwb_file_name"].replace(".nwb", "")
+        if Path(output_dir).exists():
+            output_video_filename = (
+                f"{Path(output_dir).as_posix()}/"
+                f"{nwb_base_filename}_{epoch:02d}_"
+                f'{key["dlc_si_cohort_centroid"]}_'
+                f'{key["dlc_centroid_params_name"]}'
+                f'{key["dlc_orientation_params_name"]}.mp4'
+            )
+        else:
+            output_video_filename = (
+                f"{nwb_base_filename}_{epoch:02d}_"
+                f'{key["dlc_si_cohort_centroid"]}_'
+                f'{key["dlc_centroid_params_name"]}'
+                f'{key["dlc_orientation_params_name"]}.mp4'
+            )
+        idx = pd.IndexSlice
+        video_frame_inds = position_info_df["video_frame_ind"].astype(int).to_numpy()
+        centroids = {
+            bodypart: pose_estimation_df.loc[:, idx[bodypart, ("x", "y")]].to_numpy()
+            for bodypart in pose_estimation_df.columns.levels[0]
+        }
+        position_mean = np.asarray(position_info_df[["position_x", "position_y"]])
+        orientation_mean = np.asarray(position_info_df[["orientation"]])
+        position_time = np.asarray(position_info_df.index)
+        cm_per_pixel = meters_per_pixel * M_TO_CM
+
+        print("Making video...")
+        self.make_video(
+            video_filename,
+            centroids,
+            position_mean,
+            orientation_mean,
+            position_time,
+            video_frame_inds,
+            output_video_filename=output_video_filename,
+            cm_to_pixels=cm_per_pixel,
+            disable_progressbar=False,
+            crop=None,
+        )
+
+    @staticmethod
+    def convert_to_pixels(data, frame_size, cm_to_pixels=1.0):
+        """Converts from cm to pixels and flips the y-axis.
+        Parameters
+        ----------
+        data : ndarray, shape (n_time, 2)
+        frame_size : array_like, shape (2,)
+        cm_to_pixels : float
+        Returns
+        -------
+        converted_data : ndarray, shape (n_time, 2)
+        """
+        return data / cm_to_pixels
+
+    @staticmethod
+    def fill_nan(variable, video_time, variable_time):
+        video_ind = np.digitize(variable_time, video_time[1:])
+
+        n_video_time = len(video_time)
+        try:
+            n_variable_dims = variable.shape[1]
+            filled_variable = np.full((n_video_time, n_variable_dims), np.nan)
+        except IndexError:
+            filled_variable = np.full((n_video_time,), np.nan)
+        filled_variable[video_ind] = variable
+
+        return filled_variable
+
+    def make_video(
+        self,
+        video_filename,
+        centroids,
+        position_mean,
+        orientation_mean,
+        position_time,
+        video_frame_inds,
+        output_video_filename="output.mp4",
+        cm_to_pixels=1.0,
+        disable_progressbar=False,
+        crop=None,
+        arrow_radius=15,
+        circle_radius=8,
+    ):
+        import matplotlib.animation as animation
+        import matplotlib.font_manager as fm
+
+        frame_offset = -1
+        time_slice = []
+        video_slowdown = 1
+        vmax = 0.07  # ?
+        # Set up formatting for the movie files
+
+        window_size = 501
+
+        window_ind = np.arange(window_size) - window_size // 2
+        # Get video frames
+        assert Path(
+            video_filename
+        ).exists(), f"Path to video: {video_filename} does not exist"
+        color_swatch = [
+            "#29ff3e",
+            "#ff0073",
+            "#ff291a",
+            "#1e2cff",
+            "#b045f3",
+            "#ffe91a",
+        ]
+        video = cv2.VideoCapture(video_filename)
+        fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+        frame_size = (int(video.get(3)), int(video.get(4)))
+        frame_rate = video.get(5)
+        Writer = animation.writers["ffmpeg"]
+        fps = int(np.round(frame_rate / video_slowdown))
+        writer = Writer(fps=fps, bitrate=-1)
+        n_frames = np.max(video_frame_inds)
+        ret, frame = video.read()
+        print(f"initial frame: {video.get(1)}")
+        frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+        if crop:
+            frame = frame[crop[2] : crop[3], crop[0] : crop[1]].copy()
+            crop_offset_x = crop[0]
+            crop_offset_y = crop[2]
+        frame_ind = 0
+        ### TODO: ------ DELETE THIS------- #####
+        n_frames = int(n_frames // 15)
+        with plt.style.context("dark_background"):
+            # Set up plots
+            fig, axes = plt.subplots(
+                2,
+                1,
+                figsize=(8, 6),
+                gridspec_kw={"height_ratios": [8, 1]},
+                constrained_layout=False,
+            )
+
+            axes[0].tick_params(colors="white", which="both")
+            axes[0].spines["bottom"].set_color("white")
+            axes[0].spines["left"].set_color("white")
+            image = axes[0].imshow(frame, animated=True)
+            print(f"frame after init plot: {video.get(1)}")
+            centroid_plot_objs = {
+                bodypart: axes[0].scatter(
+                    [],
+                    [],
+                    s=2,
+                    zorder=102,
+                    color=color,
+                    label=f"{bodypart} position",
+                    animated=True,
+                    alpha=0.6,
+                )
+                for color, bodypart in zip(color_swatch, centroids.keys())
+            }
+            centroid_position_dot = axes[0].scatter(
+                [],
+                [],
+                s=5,
+                zorder=102,
+                color="#b045f3",
+                label="centroid position",
+                animated=True,
+                alpha=0.6,
+            )
+            (orientation_line,) = axes[0].plot(
+                [],
+                [],
+                color="cyan",
+                linewidth=1,
+                animated=True,
+                label="Orientation",
+            )
+            axes[0].set_xlabel("")
+            axes[0].set_ylabel("")
+            ratio = frame_size[1] / frame_size[0]
+            if crop:
+                ratio = (crop[3] - crop[2]) / (crop[1] - crop[0])
+            x_left, x_right = axes[0].get_xlim()
+            y_low, y_high = axes[0].get_ylim()
+            axes[0].set_aspect(abs((x_right - x_left) / (y_low - y_high)) * ratio)
+            #     axes[0].set_xlim(position_info[position_name[0]].min() - 10,
+            #                      position_info[position_name[0]].max() + 10)
+            #     axes[0].set_ylim(position_info[position_name[1]].min() - 10,
+            #                      position_info[position_name[1]].max() + 10)
+            axes[0].spines["top"].set_color("black")
+            axes[0].spines["right"].set_color("black")
+            time_delta = pd.Timedelta(
+                position_time[0] - position_time[0]
+            ).total_seconds()
+            axes[0].legend(loc="lower right", fontsize=4)
+            title = axes[0].set_title(
+                f"time = {time_delta:3.4f}s\n frame = {frame_ind}",
+                fontsize=8,
+            )
+            fontprops = fm.FontProperties(size=12)
+            #     scalebar = AnchoredSizeBar(axes[0].transData,
+            #                                20, '20 cm', 'lower right',
+            #                                pad=0.1,
+            #                                color='white',
+            #                                frameon=False,
+            #                                size_vertical=1,
+            #                                fontproperties=fontprops)
+
+            #     axes[0].add_artist(scalebar)
+            axes[0].axis("off")
+            # if plot_likelihood:
+            #     (redL_likelihood,) = axes[1].plot(
+            #         [],
+            #         [],
+            #         color="yellow",
+            #         linewidth=1,
+            #         animated=True,
+            #         clip_on=False,
+            #         label="red_left",
+            #     )
+            #     (redR_likelihood,) = axes[1].plot(
+            #         [],
+            #         [],
+            #         color="blue",
+            #         linewidth=1,
+            #         animated=True,
+            #         clip_on=False,
+            #         label="red_right",
+            #     )
+            #     (green_likelihood,) = axes[1].plot(
+            #         [],
+            #         [],
+            #         color="green",
+            #         linewidth=1,
+            #         animated=True,
+            #         clip_on=False,
+            #         label="green",
+            #     )
+            #     (redC_likelihood,) = axes[1].plot(
+            #         [],
+            #         [],
+            #         color="red",
+            #         linewidth=1,
+            #         animated=True,
+            #         clip_on=False,
+            #         label="red_center",
+            #     )
+            #     axes[1].set_ylim((0.0, 1))
+            #     axes[1].set_xlim(
+            #         (
+            #             window_ind[0] / sampling_frequency,
+            #             window_ind[-1] / sampling_frequency,
+            #         )
+            #     )
+            #     axes[1].set_xlabel("Time [s]")
+            #     axes[1].set_ylabel("Likelihood")
+            #     axes[1].set_facecolor("black")
+            #     axes[1].spines["top"].set_color("black")
+            #     axes[1].spines["right"].set_color("black")
+            #     axes[1].legend(loc="upper right", fontsize=4)
+            progress_bar = tqdm(leave=True, position=0)
+            progress_bar.reset(total=n_frames)
+
+            def _update_plot(time_ind):
+                if time_ind == 0:
+                    video.set(1, time_ind + 1)
+                ret, frame = video.read()
+                if ret:
+                    frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+                    if crop:
+                        frame = frame[crop[2] : crop[3], crop[0] : crop[1]].copy()
+                    image.set_array(frame)
+                pos_ind = np.where(video_frame_inds == time_ind)[0]
+                if len(pos_ind) == 0:
+                    centroid_position_dot.set_offsets((np.NaN, np.NaN))
+                    for bodypart in centroid_plot_objs.keys():
+                        centroid_plot_objs[bodypart].set_offsets((np.NaN, np.NaN))
+                    orientation_line.set_data((np.NaN, np.NaN))
+                    title.set_text(f"time = {0:3.4f}s\n frame = {time_ind}")
+                else:
+                    pos_ind = pos_ind[0]
+                    dlc_centroid_data = self.convert_to_pixels(
+                        position_mean[pos_ind], frame, cm_to_pixels
+                    )
+                    if crop:
+                        dlc_centroid_data = np.hstack(
+                            (
+                                self.convert_to_pixels(
+                                    position_mean[pos_ind, 0, np.newaxis],
+                                    frame,
+                                    cm_to_pixels,
+                                )
+                                - crop_offset_x,
+                                self.convert_to_pixels(
+                                    position_mean[pos_ind, 1, np.newaxis],
+                                    frame,
+                                    cm_to_pixels,
+                                )
+                                - crop_offset_y,
+                            )
+                        )
+                    for bodypart in centroid_plot_objs.keys():
+                        centroid_plot_objs[bodypart].set_offsets(
+                            self.convert_to_pixels(
+                                centroids[bodypart][pos_ind], frame, cm_to_pixels
+                            )
+                        )
+                    centroid_position_dot.set_offsets(dlc_centroid_data)
+                    r = 30
+                    orientation_line.set_data(
+                        [
+                            dlc_centroid_data[0],
+                            dlc_centroid_data[0]
+                            + r * np.cos(orientation_mean[pos_ind]),
+                        ],
+                        [
+                            dlc_centroid_data[1],
+                            dlc_centroid_data[1]
+                            + r * np.sin(orientation_mean[pos_ind]),
+                        ],
+                    )
+                    # Need to convert times to datetime object probably.
+
+                    time_delta = pd.Timedelta(
+                        pd.to_datetime(position_time[pos_ind] * 1e9, unit="ns")
+                        - pd.to_datetime(position_time[0] * 1e9, unit="ns")
+                    ).total_seconds()
+                    title.set_text(f"time = {time_delta:3.4f}s\n frame = {time_ind}")
+                # redL_likelihood.set_data(
+                #     window_ind / sampling_frequency,
+                #     np.asarray(
+                #         interp_df["redLED_L", "likelihood"].iloc[time_ind + window_ind]
+                #     ),
+                # )
+                # redR_likelihood.set_data(
+                #     window_ind / sampling_frequency,
+                #     np.asarray(
+                #         interp_df["redLED_R", "likelihood"].iloc[time_ind + window_ind]
+                #     ),
+                # )
+                # green_likelihood.set_data(
+                #     window_ind / sampling_frequency,
+                #     np.asarray(
+                #         interp_df["greenLED", "likelihood"].iloc[time_ind + window_ind]
+                #     ),
+                # )
+                # redC_likelihood.set_data(
+                #     window_ind / sampling_frequency,
+                #     np.asarray(
+                #         interp_df["redLED_C", "likelihood"].iloc[time_ind + window_ind]
+                #     ),
+                # )
+                progress_bar.update()
+
+                return (
+                    image,
+                    centroid_position_dot,
+                    orientation_line,
+                    title,
+                    # redC_likelihood,
+                    # green_likelihood,
+                    # redL_likelihood,
+                    # redR_likelihood,
+                )
+
+            movie = animation.FuncAnimation(
+                fig,
+                _update_plot,
+                frames=np.arange(0, n_frames + 3),
+                interval=1000 / fps,
+                blit=True,
+            )
+            movie.save(output_video_filename, writer=writer, dpi=400)
+            video.release()

--- a/spyglass_dlc/dgramling_dlc_selection.py
+++ b/spyglass_dlc/dgramling_dlc_selection.py
@@ -51,7 +51,7 @@ class DLCPos(dj.Computed):
         idx = pd.IndexSlice
         position.create_spatial_series(
             name="position",
-            timestamps=final_df["time"],
+            timestamps=final_df.index.to_numpy(),
             conversion=METERS_PER_CM,
             data=final_df.loc[:, idx[("position_x", "position_y")]],
             reference_frame=spatial_series.reference_frame,
@@ -61,7 +61,7 @@ class DLCPos(dj.Computed):
 
         orientation.create_spatial_series(
             name="orientation",
-            timestamps=final_df["time"],
+            timestamps=final_df.index.to_numpy(),
             conversion=1.0,
             data=final_df.loc[:, idx[("orientation")]],
             reference_frame=spatial_series.reference_frame,
@@ -71,7 +71,7 @@ class DLCPos(dj.Computed):
 
         velocity.create_timeseries(
             name="velocity",
-            timestamps=final_df["time"],
+            timestamps=final_df.index.to_numpy(),
             conversion=METERS_PER_CM,
             unit="m/s",
             data=final_df.loc[:, idx[("velocity_x", "velocity_y", "speed")]],

--- a/spyglass_dlc/dgramling_dlc_selection.py
+++ b/spyglass_dlc/dgramling_dlc_selection.py
@@ -6,6 +6,7 @@ import pynwb.behavior
 from spyglass.common.dj_helper_fn import fetch_nwb
 from spyglass.common.common_nwbfile import AnalysisNwbfile
 from spyglass.common.common_behav import RawPosition
+from spyglass.common.common_interval import IntervalList
 from .dgramling_dlc_centroid import DLCCentroid
 from .dgramling_dlc_orient import DLCOrientation
 
@@ -13,14 +14,10 @@ schema = dj.schema("dgramling_dlc_selection")
 
 
 @schema
-class DLCPosSelect(dj.Manual):
+class DLCPosSelection(dj.Manual):
     definition = """
-    -> IntervalList
-    dlc_position_selection_name: varchar(50)
-    ---
-    -> DLCCentroid
-    -> DLCOrientation
-    dlc_si_cohort_selection_names : blob    # List of Smooth interp cohorts used for centroid/orientation calculation
+    -> DLCCentroid.proj(dlc_si_cohort_centroid='dlc_si_cohort_selection_name')
+    -> DLCOrientation.proj(dlc_si_cohort_orientation='dlc_si_cohort_selection_name')
     """
 
 
@@ -33,7 +30,7 @@ but may be difficult to resolve primary keys if cohorts different
 @schema
 class DLCPos(dj.Computed):
     definition = """
-    -> DLCPosSelect
+    -> DLCPosSelection
     ---
     -> AnalysisNwbfile
     position_object_id      : varchar(80)

--- a/spyglass_dlc/dgramling_dlc_training.py
+++ b/spyglass_dlc/dgramling_dlc_training.py
@@ -1,12 +1,7 @@
-import numpy as np
-import pandas as pd
-import datajoint as dj
+from pathlib import Path
 import inspect
 import os
-import ruamel.yaml as yaml
-from itertools import combinations
-from pathlib import Path
-from .dlc_utils import find_full_path
+import datajoint as dj
 from .dgramling_dlc_project import DLCProject
 
 schema = dj.schema("dgramling_dlc_training")

--- a/spyglass_dlc/dgramling_position.py
+++ b/spyglass_dlc/dgramling_position.py
@@ -1,8 +1,6 @@
 import datajoint as dj
 import pandas as pd
 import numpy as np
-import pynwb
-import pynwb.behavior
 from spyglass.common.dj_helper_fn import fetch_nwb
 from spyglass.common.common_nwbfile import AnalysisNwbfile
 from spyglass.common.common_interval import IntervalList

--- a/spyglass_dlc/dgramling_position.py
+++ b/spyglass_dlc/dgramling_position.py
@@ -5,6 +5,9 @@ import pynwb
 import pynwb.behavior
 from spyglass.common.dj_helper_fn import fetch_nwb
 from spyglass.common.common_nwbfile import AnalysisNwbfile
+from spyglass.common.common_interval import IntervalList
+from .dgramling_dlc_selection import DLCPos
+from .dgramling_trodes_position import TrodesPos
 
 schema = dj.schema("dgramling_position")
 
@@ -13,6 +16,7 @@ schema = dj.schema("dgramling_position")
 class PosSelect(dj.Manual):
     """ """
 
+    # TODO: I think the IntervalList dependency should be replaced by a table further downstream
     definition = """
     -> IntervalList
     ---

--- a/spyglass_dlc/dgramling_trodes_position.py
+++ b/spyglass_dlc/dgramling_trodes_position.py
@@ -13,7 +13,6 @@ from position_tools import (
     interpolate_nan,
 )
 from position_tools.core import gaussian_smooth
-from tqdm import tqdm_notebook as tqdm
 from spyglass.common.dj_helper_fn import fetch_nwb
 from spyglass.common.common_nwbfile import AnalysisNwbfile
 from spyglass.common.common_behav import RawPosition

--- a/spyglass_dlc/dgramling_trodes_position.py
+++ b/spyglass_dlc/dgramling_trodes_position.py
@@ -27,8 +27,6 @@ class TrodesPosParams(dj.Manual):
     Parameters for calculating the position (centroid, velocity, orientation)
     """
 
-    # TODO: whether to keep all params in a params dict
-    # or break out into individual secondary keys
     definition = """
     trodes_pos_params_name: varchar(80) # name for this set of parameters
     ---
@@ -78,9 +76,9 @@ class TrodesPos(dj.Computed):
     -> TrodesPosSelection
     ---
     -> AnalysisNwbfile
-    trodes_centroid_object_id : varchar(80)
-    trodes_orientation_object_id : varchar(80)
-    trodes_velocity_object_id : varchar(80)
+    centroid_object_id : varchar(80)
+    orientation_object_id : varchar(80)
+    velocity_object_id : varchar(80)
     """
 
     def make(self, key):

--- a/spyglass_dlc/dgramling_trodes_position.py
+++ b/spyglass_dlc/dgramling_trodes_position.py
@@ -48,7 +48,10 @@ class TrodesPosParams(dj.Manual):
             "upsampling_sampling_rate": None,
             "upsampling_interpolation_method": "linear",
         }
-        cls.insert1({"trodes_pos_params_name": "default", "params": params})
+        cls.insert1(
+            {"trodes_pos_params_name": "default", "params": params},
+            skip_duplicates=True,
+        )
 
 
 @schema
@@ -75,7 +78,7 @@ class TrodesPos(dj.Computed):
     -> TrodesPosSelection
     ---
     -> AnalysisNwbfile
-    centroid_object_id : varchar(80)
+    position_object_id : varchar(80)
     orientation_object_id : varchar(80)
     velocity_object_id : varchar(80)
     """
@@ -85,7 +88,6 @@ class TrodesPos(dj.Computed):
         key["analysis_file_name"] = AnalysisNwbfile().create(key["nwb_file_name"])
         raw_position = (RawPosition() & key).fetch_nwb()[0]
         position_info_parameters = (TrodesPosParams() & key).fetch1("params")
-
         position = pynwb.behavior.Position()
         orientation = pynwb.behavior.CompassDirection()
         velocity = pynwb.behavior.BehavioralTimeSeries()
@@ -107,7 +109,6 @@ class TrodesPos(dj.Computed):
                 position_info_parameters["upsampling_sampling_rate"],
                 position_info_parameters["upsampling_interpolation_method"],
             )
-
             # create nwb objects for insertion into analysis nwb file
             position.create_spatial_series(
                 name="position",
@@ -140,6 +141,14 @@ class TrodesPos(dj.Computed):
                 ),
                 comments=spatial_series.comments,
                 description="x_velocity, y_velocity, speed",
+            )
+            velocity.create_timeseries(
+                name="video_frame_ind",
+                unit="index",
+                timestamps=position_info["time"],
+                data=raw_position["raw_position"].data,
+                description="video_frame_ind",
+                comments=spatial_series.comments,
             )
         except ValueError:
             pass
@@ -330,6 +339,7 @@ class TrodesPos(dj.Computed):
             name="time",
         )
         COLUMNS = [
+            "video_frame_ind",
             "position_x",
             "position_y",
             "orientation",
@@ -340,6 +350,10 @@ class TrodesPos(dj.Computed):
         return pd.DataFrame(
             np.concatenate(
                 (
+                    np.asarray(
+                        nwb_data["velocity"].time_series["video_frame_ind"].data,
+                        dtype=int,
+                    )[:, np.newaxis],
                     np.asarray(nwb_data["position"].get_spatial_series().data),
                     np.asarray(nwb_data["orientation"].get_spatial_series().data)[
                         :, np.newaxis

--- a/spyglass_dlc/dlc_reader.py
+++ b/spyglass_dlc/dlc_reader.py
@@ -191,7 +191,7 @@ def save_yaml(output_dir, config_dict, filename="dj_dlc_config", mkdir=True):
     if "config_template" in config_dict:  # if passed full model.Model dict
         config_dict = config_dict["config_template"]
     if mkdir:
-        output_dir.mkdir(exist_ok=True)
+        Path(output_dir).mkdir(exist_ok=True)
     if "." in filename:  # if user provided extension, remove
         filename = filename.split(".")[0]
 
@@ -240,7 +240,6 @@ def do_pose_estimation(
     # To project dir: Required by DLC to run the analyze_videos
     if dlc_project_path != output_dir:
         config_filepath = save_yaml(dlc_project_path, dlc_config)
-
     # ---- Trigger DLC prediction job ----
     analyze_videos(
         config=config_filepath,

--- a/spyglass_dlc/dlc_reader.py
+++ b/spyglass_dlc/dlc_reader.py
@@ -162,7 +162,7 @@ def read_yaml(fullpath, filename="*"):
 
     # Take the DJ-saved if there. If not, return list of available
     yml_paths = list(Path(fullpath).glob("dj_dlc_config.yaml")) or sorted(
-        list(Path(fullpath).glob("{filename}.y*ml"))
+        list(Path(fullpath).glob(f"{filename}.y*ml"))
     )
 
     assert (  # If more than 1 and not DJ-saved,

--- a/spyglass_dlc/dlc_utils.py
+++ b/spyglass_dlc/dlc_utils.py
@@ -3,11 +3,9 @@
 
 import pathlib
 import os
-import glob
-
-## from workflow-deeplabcut.paths
-import datajoint as dj
 from collections import abc
+from typing import Union
+import datajoint as dj
 
 
 def get_dlc_root_data_dir():
@@ -103,6 +101,86 @@ def _to_Path(path):
     return pathlib.Path(str(path).replace("\\", "/"))
 
 
+def get_video_path(key):
+    """
+    Given nwb_file_name and interval_list_name returns specified
+    video file filename and path
+
+    Parameters
+    ----------
+    key : dict
+        Dictionary containing nwb_file_name and interval_list_name as keys
+    Returns
+    -------
+    video_filepath : str
+        path to the video file, including video filename
+    video_filename : str
+        filename of the video
+    """
+    from spyglass.common.common_behav import VideoFile
+    import pynwb
+
+    video_info = (
+        VideoFile() & {"nwb_file_name": key["nwb_file_name"], "epoch": key["epoch"]}
+    ).fetch1()
+    io = pynwb.NWBHDF5IO("/stelmo/nwb/raw/" + video_info["nwb_file_name"], "r")
+    nwb_file = io.read()
+    nwb_video = nwb_file.objects[video_info["video_file_object_id"]]
+    video_filepath = nwb_video.external_file[0]
+    video_dir = os.path.dirname(video_filepath) + "/"
+    video_filename = video_filepath.split(video_dir)[-1]
+    return video_dir, video_filename
+
+
+def check_videofile(
+    video_path: Union[str, pathlib.PosixPath],
+    output_path: Union[str, pathlib.PosixPath],
+    video_filename: str = None,
+    video_filetype: str = "h264",
+):
+    """
+    Checks the file extension of a video file to make sure it is .mp4 for
+    DeepLabCut processes. Converts to MP4 if not already.
+
+    Parameters
+    ----------
+    video_path : str or PosixPath object
+        path to directory of the existing video file without filename
+    output_path : str or PosixPath object
+        path to directory where converted video will be saved
+    video_filename : str, Optional
+        filename of the video to convert, if not provided, video_filetype must be
+        and all video files of video_filetype in the directory will be converted
+    video_filetype : str or List, Default 'h264', Optional
+        If video_filename is not provided,
+        all videos of this filetype will be converted to .mp4
+
+    Returns
+    -------
+    output_files : List of PosixPath objects
+        paths to converted video file(s)
+    """
+    if not video_filename:
+        video_files = pathlib.Path(video_path).glob(f"*.{video_filetype}")
+    else:
+        video_files = [pathlib.Path(f"{video_path}/{video_filename}")]
+    output_files = []
+    for video_filepath in video_files:
+        if video_filepath.exists():
+            if video_filepath.suffix == ".mp4":
+                output_files.append(video_filepath)
+                continue
+        video_file = (
+            video_filepath.as_posix()
+            .rsplit(video_filepath.parent.as_posix(), maxsplit=1)[-1]
+            .split("/")[-1]
+        )
+        output_files.append(
+            _convert_mp4(video_file, video_path, output_path, videotype="mp4")
+        )
+    return output_files
+
+
 def _convert_mp4(
     filename: str,
     video_path: str,
@@ -131,14 +209,17 @@ def _convert_mp4(
     import subprocess
 
     orig_filename = filename
-    video_path = pathlib.Path(video_path + filename)
+    video_path = pathlib.PurePath(pathlib.Path(video_path), pathlib.Path(filename))
     if videotype not in ["mp4"]:
         raise NotImplementedError
     dest_filename = os.path.splitext(filename)[0]
     if ".1" in dest_filename:
         dest_filename = os.path.splitext(dest_filename)[0]
     dest_path = pathlib.Path(f"{dest_path}/{dest_filename}.{videotype}")
-    convert_command = f"ffmpeg -vsync passthrough -i {video_path.as_posix()} -codec copy {dest_path.as_posix()}"
+    convert_command = (
+        f"ffmpeg -vsync passthrough -i {video_path.as_posix()} "
+        f"-codec copy {dest_path.as_posix()}"
+    )
     os.system(convert_command)
     print(f"finished converting {filename}")
     print(

--- a/spyglass_dlc/dlc_utils.py
+++ b/spyglass_dlc/dlc_utils.py
@@ -137,10 +137,8 @@ def _convert_mp4(
     dest_filename = os.path.splitext(filename)[0]
     if ".1" in dest_filename:
         dest_filename = os.path.splitext(dest_filename)[0]
-    dest_path = pathlib.Path(dest_path + dest_filename + "." + videotype)
-    convert_command = (
-        f"ffmpeg -vsync passthrough -i {video_path} -codec copy {dest_path}"
-    )
+    dest_path = pathlib.Path(f"{dest_path}/{dest_filename}.{videotype}")
+    convert_command = f"ffmpeg -vsync passthrough -i {video_path.as_posix()} -codec copy {dest_path.as_posix()}"
     os.system(convert_command)
     print(f"finished converting {filename}")
     print(
@@ -159,7 +157,7 @@ def _convert_mp4(
             "stream=nb_read_packets",
             "-of",
             "csv=p=0",
-            file,
+            file.as_posix(),
         ]
         frames_command = [
             "ffprobe",
@@ -172,7 +170,7 @@ def _convert_mp4(
             "stream=nb_read_frames",
             "-of",
             "csv=p=0",
-            file,
+            file.as_posix(),
         ]
         if count_frames:
             p = subprocess.Popen(


### PR DESCRIPTION
- Move conversion from pixels to cm and timestamp addition to `DLCPoseEstimation` (required referencing `RawPosition`)
- Allow for passing `nwb_file_name` and `epoch` to `DLCProject` for conversion to MP4 and addition to project's training video set.
- Cleaned up functions and moved to `dlc_utils.py`. Added function to set directory permissions for project directory depending on lab team... not tested and not fully implemented yet. 
- Change dependency for `DLCSmoothInterpSelection` from `DLCPoseEstimation` and `BodyPart` to `DLCPoseEstimation.BodyPart`. 
- Added `video_frame_ind` to dataframe and nwb object outputs for `DLCPoseEstimation`, `DLCCentroid`, `DLCPos`, etc...
    - this now exists as part of the `velocity` nwb object
- Tried modifying `pose_cfg.yaml` during `DLCModelTraining` to reflect user running training, but led to bugs. Instead, added call to `deeplabcut.create_training_dataset`, which should create new `pose_cfg.yaml` for each user populating `DLCModelTraining` and reference their own path for `init_weights`.
- Added params for `deeplabcut.create_training_dataset` to `DLCModelTrainingParams`
- Changed dependency for `DLCSmoothInterpCohortSelection` from individual keys to a dependence on `DLCPoseEstimation` with added primary key: `dlc_si_cohort_selection_name`. Which ensures dependence chain all the way to `PosSource`. This may not be desirable behavior....

Still To-Do:
- [ ] Make `DLCPos` and `TrodesPos` auto insert into `PosSource` part tables at end of populate.
- [ ] Above for `DLCModelTraining` and `DLCModelInput` into `DLCModelSource`
- [ ] Remove DLC pipeline dependence on `RawPosition`
- [ ] Test `_set_permissions` 