### PR TITLE
Add auto-insert into source tables

### DIFF
--- a/spyglass_dlc/__init__.py
+++ b/spyglass_dlc/__init__.py
@@ -28,7 +28,6 @@ from .dgramling_dlc_orient import (
 from .dgramling_dlc_selection import DLCPosSelection, DLCPos, DLCPosVideo
 from .dgramling_trodes_position import TrodesPosParams, TrodesPosSelection, TrodesPos
 from .dgramling_position import (
-    PosSelect,
     PosSource,
     IntervalPositionInfo,
     IntervalPositionInfoSelection,

--- a/spyglass_dlc/dgramling_dlc_centroid.py
+++ b/spyglass_dlc/dgramling_dlc_centroid.py
@@ -47,7 +47,7 @@ class DLCCentroidParams(dj.Manual):
                 "point2": "redLED_C",
             },
             "speed_smoothing_std_dev": 0.100,
-            "sampling_rate": 40,
+            "sampling_rate": 50,
         }
         cls.insert1({"dlc_centroid_params_name": "default", "params": params})
 

--- a/spyglass_dlc/dgramling_dlc_model.py
+++ b/spyglass_dlc/dgramling_dlc_model.py
@@ -31,6 +31,13 @@ class DLCModelInput(dj.Manual):
         project_path = Path(key["project_path"])
         assert project_path.exists(), "project path does not exist"
         super().insert1(key, **kwargs)
+        DLCModelSource.insert_entry(
+            dlc_model_name=key["dlc_model_name"],
+            project_name=key["project_name"],
+            source="FromImport",
+            key=key,
+            skip_duplicates=True,
+        )
 
 
 @schema

--- a/spyglass_dlc/dgramling_dlc_selection.py
+++ b/spyglass_dlc/dgramling_dlc_selection.py
@@ -121,6 +121,15 @@ class DLCPos(dj.Computed):
         )
 
         self.insert1(key)
+        from .dgramling_position import PosSource
+
+        key["source"] = "DLC"
+        dlc_key = key.copy()
+        valid_fields = PosSource().fetch().dtype.fields.keys()
+        entries_to_delete = [entry for entry in key.keys() if entry not in valid_fields]
+        for entry in entries_to_delete:
+            del key[entry]
+        PosSource().insert1(key=key, params=dlc_key, skip_duplicates=True)
 
     def fetch_nwb(self, *attrs, **kwargs):
         return fetch_nwb(

--- a/spyglass_dlc/dgramling_dlc_training.py
+++ b/spyglass_dlc/dgramling_dlc_training.py
@@ -83,7 +83,7 @@ class DLCModelTrainingSelection(dj.Manual):
     def insert1(self, key, **kwargs):
         training_id = key["training_id"]
         if training_id is None:
-            training_id = (dj.U().aggr(self, n="max(training_id)").fetch1("n") or 0) + 1
+            training_id = (dj.U().aggr(self & key, n="max(training_id)").fetch1("n") or 0) + 1
         key["training_id"] = training_id
         super().insert1(key, **kwargs)
 
@@ -217,4 +217,13 @@ class DLCModelTraining(dj.Computed):
 
         self.insert1(
             {**key, "latest_snapshot": latest_snapshot, "config_template": dlc_config}
+        )
+        from .dgramling_dlc_model import DLCModelSource
+
+        DLCModelSource.insert_entry(
+            dlc_model_name=key["dlc_model_name"],
+            project_name=key["project_name"],
+            source="FromUpstream",
+            key=key,
+            skip_duplicates=True,
         )

--- a/spyglass_dlc/dgramling_trodes_position.py
+++ b/spyglass_dlc/dgramling_trodes_position.py
@@ -169,6 +169,15 @@ class TrodesPos(dj.Computed):
         AnalysisNwbfile().add(key["nwb_file_name"], key["analysis_file_name"])
 
         self.insert1(key)
+        from .dgramling_position import PosSource
+
+        key["source"] = "Trodes"
+        trodes_key = key.copy()
+        valid_fields = PosSource().fetch().dtype.fields.keys()
+        entries_to_delete = [entry for entry in key.keys() if entry not in valid_fields]
+        for entry in entries_to_delete:
+            del key[entry]
+        PosSource().insert1(key=key, params=trodes_key, skip_duplicates=True)
 
     def calculate_position_info_from_spatial_series(
         self,


### PR DESCRIPTION
This pull request adds code to DLCModelTraining and DLCModelInput to auto-insert entries into DLCModelSource. It also adds code to DLCPos and TrodesPos to auto-insert entries into PosSource. 
This PR also addresses a bug in the auto-increment of position_id and training_id that queried all entries and incremented based off the highest value in the table instead of entries with matching primary keys outside of the incrementer. 