### PR TITLE
Fix handling of low likelihood spans that reach end of epoch

### DIFF
--- a/spyglass_dlc/dgramling_dlc_orient.py
+++ b/spyglass_dlc/dgramling_dlc_orient.py
@@ -49,7 +49,12 @@ class DLCOrientationParams(dj.Manual):
             cls().insert_default(skip_duplicates=True)
             default = (cls & {"dlc_orientation_params_name": "default"}).fetch1()
         return default
-    
+
+    @classmethod
+    def get_orient_methods(cls):
+        return _key_to_func_dict
+
+
 @schema
 class DLCOrientationSelection(dj.Manual):
     """ """
@@ -159,7 +164,7 @@ class DLCOrientation(dj.Computed):
         )
 
 
-def two_pt_head_orientation(pos_df: pd.DataFrame, **params):
+def two_pt_orientation(pos_df: pd.DataFrame, **params):
     """Determines orientation based on vector between two points"""
     BP1 = params.pop("bodypart1", None)
     BP2 = params.pop("bodypart2", None)
@@ -209,6 +214,6 @@ def red_led_bisector_orientation(pos_df: pd.DataFrame, **params):
 
 _key_to_func_dict = {
     "none": no_orientation,
-    "red_green_orientation": two_pt_head_orientation,
+    "two_pt_orientation": two_pt_orientation,
     "red_led_bisector": red_led_bisector_orientation,
 }

--- a/spyglass_dlc/dgramling_dlc_pose_estimation.py
+++ b/spyglass_dlc/dgramling_dlc_pose_estimation.py
@@ -73,7 +73,9 @@ class DLCPoseEstimationSelection(dj.Manual):
         video_path, video_filename, _, _ = get_video_path(key)
         output_dir = cls.infer_output_dir(key, video_filename=video_filename)
         video_dir = os.path.dirname(video_path) + "/"
-        video_path = check_videofile(video_path=video_dir, video_filename=video_filename)[0]
+        video_path = check_videofile(
+            video_path=video_dir, video_filename=video_filename
+        )[0]
         cls.insert1(
             {
                 **key,

--- a/spyglass_dlc/dgramling_dlc_position.py
+++ b/spyglass_dlc/dgramling_dlc_position.py
@@ -179,8 +179,11 @@ def interp_pos(dlc_df, **kwargs):
     )
     subthresh_spans = get_span_start_stop(subthresh_inds)
     for ind, (span_start, span_stop) in enumerate(subthresh_spans):
-        if (span_stop + 1) == len(dlc_df):
-            span_stop = span_stop - 1
+        if (span_stop + 1) >= len(dlc_df):
+            dlc_df.loc[idx[span_start:span_stop], idx["x"]] = np.nan
+            dlc_df.loc[idx[span_start:span_stop], idx["y"]] = np.nan
+            print(f"ind: {ind} has no endpoint with which to interpolate")
+            continue
         x = [dlc_df["x"].iloc[span_start - 1], dlc_df["x"].iloc[span_stop + 1]]
         y = [dlc_df["y"].iloc[span_start - 1], dlc_df["y"].iloc[span_stop + 1]]
         span_len = int(span_stop - span_start + 1)

--- a/spyglass_dlc/dgramling_dlc_position.py
+++ b/spyglass_dlc/dgramling_dlc_position.py
@@ -179,86 +179,45 @@ def interp_pos(dlc_df, **kwargs):
     )
     subthresh_spans = get_span_start_stop(subthresh_inds)
     for ind, (span_start, span_stop) in enumerate(subthresh_spans):
-        if not (span_stop + 1) == len(dlc_df):
-            x = [dlc_df["x"].iloc[span_start - 1], dlc_df["x"].iloc[span_stop + 1]]
-            y = [dlc_df["y"].iloc[span_start - 1], dlc_df["y"].iloc[span_stop + 1]]
-            span_len = int(span_stop - span_start + 1)
-            # TODO: determine if necessary to allow for these parameters
-            if "max_pts_to_interp" in kwargs:
-                if span_len > kwargs["max_pts_to_interp"]:
-                    if "max_cm_to_interp" in kwargs:
-                        if (
-                            np.linalg.norm(
-                                np.array([x[0], y[0]]) - np.array([x[1], y[1]])
-                            )
-                            < kwargs["max_cm_to_interp"]
-                        ):
-                            change = np.linalg.norm(
-                                np.array([x[0], y[0]]) - np.array([x[1], y[1]])
-                            )
-                            print(
-                                f"ind: {ind} length: "
-                                f"{span_len} interpolated because minimal change:\n {change}cm"
-                            )
-                        else:
-                            dlc_df.loc[idx[span_start:span_stop], idx["x"]] = np.nan
-                            dlc_df.loc[idx[span_start:span_stop], idx["y"]] = np.nan
-                            print(f"ind: {ind} length: {span_len} " f"not interpolated")
-                            continue
-            start_time = dlc_df.index[span_start]
-            stop_time = dlc_df.index[span_stop]
-            xnew = np.interp(
-                x=dlc_df.index[span_start : span_stop + 1],
-                xp=[start_time, stop_time],
-                fp=[x[0], x[-1]],
-            )
-            ynew = np.interp(
-                x=dlc_df.index[span_start : span_stop + 1],
-                xp=[start_time, stop_time],
-                fp=[y[0], y[-1]],
-            )
-            dlc_df.loc[idx[start_time:stop_time], idx["x"]] = xnew
-            dlc_df.loc[idx[start_time:stop_time], idx["y"]] = ynew
-        else:
-            x = [dlc_df["x"].iloc[span_start - 1], dlc_df["x"].iloc[span_stop]]
-            y = [dlc_df["y"].iloc[span_start - 1], dlc_df["y"].iloc[span_stop]]
-            span_len = int(span_stop - span_start)
-            # TODO: determine if necessary to allow for these parameters
-            if "max_pts_to_interp" in kwargs:
-                if span_len > kwargs["max_pts_to_interp"]:
-                    if "max_cm_to_interp" in kwargs:
-                        if (
-                            np.linalg.norm(
-                                np.array([x[0], y[0]]) - np.array([x[1], y[1]])
-                            )
-                            < kwargs["max_cm_to_interp"]
-                        ):
-                            change = np.linalg.norm(
-                                np.array([x[0], y[0]]) - np.array([x[1], y[1]])
-                            )
-                            print(
-                                f"ind: {ind} length: "
-                                f"{span_len} interpolated because minimal change:\n {change}cm"
-                            )
-                        else:
-                            dlc_df.loc[idx[span_start:-1], idx["x"]] = np.nan
-                            dlc_df.loc[idx[span_start:-1], idx["y"]] = np.nan
-                            print(f"ind: {ind} length: {span_len} " f"not interpolated")
-                            continue
-            start_time = dlc_df.index[span_start]
-            stop_time = dlc_df.index[-1]
-            xnew = np.interp(
-                x=dlc_df.index[span_start:-1],
-                xp=[start_time, stop_time],
-                fp=[x[0], x[-1]],
-            )
-            ynew = np.interp(
-                x=dlc_df.index[span_start:-1],
-                xp=[start_time, stop_time],
-                fp=[y[0], y[-1]],
-            )
-            dlc_df.loc[idx[start_time:stop_time], idx["x"]] = xnew
-            dlc_df.loc[idx[start_time:stop_time], idx["y"]] = ynew
+        if (span_stop + 1) == len(dlc_df):
+            span_stop = span_stop - 1
+        x = [dlc_df["x"].iloc[span_start - 1], dlc_df["x"].iloc[span_stop + 1]]
+        y = [dlc_df["y"].iloc[span_start - 1], dlc_df["y"].iloc[span_stop + 1]]
+        span_len = int(span_stop - span_start + 1)
+        # TODO: determine if necessary to allow for these parameters
+        if "max_pts_to_interp" in kwargs:
+            if span_len > kwargs["max_pts_to_interp"]:
+                if "max_cm_to_interp" in kwargs:
+                    if (
+                        np.linalg.norm(np.array([x[0], y[0]]) - np.array([x[1], y[1]]))
+                        < kwargs["max_cm_to_interp"]
+                    ):
+                        change = np.linalg.norm(
+                            np.array([x[0], y[0]]) - np.array([x[1], y[1]])
+                        )
+                        print(
+                            f"ind: {ind} length: "
+                            f"{span_len} interpolated because minimal change:\n {change}cm"
+                        )
+                    else:
+                        dlc_df.loc[idx[span_start:span_stop], idx["x"]] = np.nan
+                        dlc_df.loc[idx[span_start:span_stop], idx["y"]] = np.nan
+                        print(f"ind: {ind} length: {span_len} " f"not interpolated")
+                        continue
+        start_time = dlc_df.index[span_start]
+        stop_time = dlc_df.index[span_stop]
+        xnew = np.interp(
+            x=dlc_df.index[span_start : span_stop + 1],
+            xp=[start_time, stop_time],
+            fp=[x[0], x[-1]],
+        )
+        ynew = np.interp(
+            x=dlc_df.index[span_start : span_stop + 1],
+            xp=[start_time, stop_time],
+            fp=[y[0], y[-1]],
+        )
+        dlc_df.loc[idx[start_time:stop_time], idx["x"]] = xnew
+        dlc_df.loc[idx[start_time:stop_time], idx["y"]] = ynew
     return dlc_df
 
 

--- a/spyglass_dlc/dgramling_dlc_position.py
+++ b/spyglass_dlc/dgramling_dlc_position.py
@@ -179,43 +179,86 @@ def interp_pos(dlc_df, **kwargs):
     )
     subthresh_spans = get_span_start_stop(subthresh_inds)
     for ind, (span_start, span_stop) in enumerate(subthresh_spans):
-        x = [dlc_df["x"].iloc[span_start - 1], dlc_df["x"].iloc[span_stop + 1]]
-        y = [dlc_df["y"].iloc[span_start - 1], dlc_df["y"].iloc[span_stop + 1]]
-        span_len = int(span_stop - span_start + 1)
-        # TODO: determine if necessary to allow for these parameters
-        if "max_pts_to_interp" in kwargs:
-            if span_len > kwargs["max_pts_to_interp"]:
-                if "max_cm_to_interp" in kwargs:
-                    if (
-                        np.linalg.norm(np.array([x[0], y[0]]) - np.array([x[1], y[1]]))
-                        < kwargs["max_cm_to_interp"]
-                    ):
-                        change = np.linalg.norm(
-                            np.array([x[0], y[0]]) - np.array([x[1], y[1]])
-                        )
-                        print(
-                            f"ind: {ind} length: "
-                            f"{span_len} interpolated because minimal change:\n {change}cm"
-                        )
-                    else:
-                        dlc_df.loc[idx[span_start:span_stop], idx["x"]] = np.nan
-                        dlc_df.loc[idx[span_start:span_stop], idx["y"]] = np.nan
-                        print(f"ind: {ind} length: {span_len} " f"not interpolated")
-                        continue
-        start_time = dlc_df.index[span_start]
-        stop_time = dlc_df.index[span_stop]
-        xnew = np.interp(
-            x=dlc_df.index[span_start : span_stop + 1],
-            xp=[start_time, stop_time],
-            fp=[x[0], x[-1]],
-        )
-        ynew = np.interp(
-            x=dlc_df.index[span_start : span_stop + 1],
-            xp=[start_time, stop_time],
-            fp=[y[0], y[-1]],
-        )
-        dlc_df.loc[idx[start_time:stop_time], idx["x"]] = xnew
-        dlc_df.loc[idx[start_time:stop_time], idx["y"]] = ynew
+        if not (span_stop + 1) == len(dlc_df):
+            x = [dlc_df["x"].iloc[span_start - 1], dlc_df["x"].iloc[span_stop + 1]]
+            y = [dlc_df["y"].iloc[span_start - 1], dlc_df["y"].iloc[span_stop + 1]]
+            span_len = int(span_stop - span_start + 1)
+            # TODO: determine if necessary to allow for these parameters
+            if "max_pts_to_interp" in kwargs:
+                if span_len > kwargs["max_pts_to_interp"]:
+                    if "max_cm_to_interp" in kwargs:
+                        if (
+                            np.linalg.norm(
+                                np.array([x[0], y[0]]) - np.array([x[1], y[1]])
+                            )
+                            < kwargs["max_cm_to_interp"]
+                        ):
+                            change = np.linalg.norm(
+                                np.array([x[0], y[0]]) - np.array([x[1], y[1]])
+                            )
+                            print(
+                                f"ind: {ind} length: "
+                                f"{span_len} interpolated because minimal change:\n {change}cm"
+                            )
+                        else:
+                            dlc_df.loc[idx[span_start:span_stop], idx["x"]] = np.nan
+                            dlc_df.loc[idx[span_start:span_stop], idx["y"]] = np.nan
+                            print(f"ind: {ind} length: {span_len} " f"not interpolated")
+                            continue
+            start_time = dlc_df.index[span_start]
+            stop_time = dlc_df.index[span_stop]
+            xnew = np.interp(
+                x=dlc_df.index[span_start : span_stop + 1],
+                xp=[start_time, stop_time],
+                fp=[x[0], x[-1]],
+            )
+            ynew = np.interp(
+                x=dlc_df.index[span_start : span_stop + 1],
+                xp=[start_time, stop_time],
+                fp=[y[0], y[-1]],
+            )
+            dlc_df.loc[idx[start_time:stop_time], idx["x"]] = xnew
+            dlc_df.loc[idx[start_time:stop_time], idx["y"]] = ynew
+        else:
+            x = [dlc_df["x"].iloc[span_start - 1], dlc_df["x"].iloc[span_stop]]
+            y = [dlc_df["y"].iloc[span_start - 1], dlc_df["y"].iloc[span_stop]]
+            span_len = int(span_stop - span_start)
+            # TODO: determine if necessary to allow for these parameters
+            if "max_pts_to_interp" in kwargs:
+                if span_len > kwargs["max_pts_to_interp"]:
+                    if "max_cm_to_interp" in kwargs:
+                        if (
+                            np.linalg.norm(
+                                np.array([x[0], y[0]]) - np.array([x[1], y[1]])
+                            )
+                            < kwargs["max_cm_to_interp"]
+                        ):
+                            change = np.linalg.norm(
+                                np.array([x[0], y[0]]) - np.array([x[1], y[1]])
+                            )
+                            print(
+                                f"ind: {ind} length: "
+                                f"{span_len} interpolated because minimal change:\n {change}cm"
+                            )
+                        else:
+                            dlc_df.loc[idx[span_start:-1], idx["x"]] = np.nan
+                            dlc_df.loc[idx[span_start:-1], idx["y"]] = np.nan
+                            print(f"ind: {ind} length: {span_len} " f"not interpolated")
+                            continue
+            start_time = dlc_df.index[span_start]
+            stop_time = dlc_df.index[-1]
+            xnew = np.interp(
+                x=dlc_df.index[span_start:-1],
+                xp=[start_time, stop_time],
+                fp=[x[0], x[-1]],
+            )
+            ynew = np.interp(
+                x=dlc_df.index[span_start:-1],
+                xp=[start_time, stop_time],
+                fp=[y[0], y[-1]],
+            )
+            dlc_df.loc[idx[start_time:stop_time], idx["x"]] = xnew
+            dlc_df.loc[idx[start_time:stop_time], idx["y"]] = ynew
     return dlc_df
 
 


### PR DESCRIPTION
There is a case where a span of low likelihood frames would reach the end of the data (e.g. if the bodypart is occluded when the recording ends). This PR sets the position for these frames to NaN since there is no valid, high-likelihood endpoint with which to interpolate. 

Unfortunately, I also threw in some naming and formatting changes that are relatively minor.